### PR TITLE
Radial acc

### DIFF
--- a/inc/VAnaSumRunParameter.h
+++ b/inc/VAnaSumRunParameter.h
@@ -231,6 +231,10 @@ class VAnaSumRunParameter : public TNamed, public VGlobalRunParameter
             return fVersion;
         }
         vector<VListOfExclusionRegions*> getExclusionRegions( unsigned int iRunCounter );
+        VExclusionRegions* getExclusionRegions()
+        {
+             return fExclusionRegions;
+        }
         void getEventdisplayRunParameter( string );
         double getLargestStarExlusionRadius();
         VGammaHadronCuts* getGammaHadronCuts( string ifile );
@@ -265,6 +269,6 @@ class VAnaSumRunParameter : public TNamed, public VGlobalRunParameter
         bool writeListOfExcludedSkyRegions( int inonRun );
         bool getListOfExcludedSkyRegions( TFile* f, int inonRun );
         
-        ClassDef( VAnaSumRunParameter, 16 );
+        ClassDef( VAnaSumRunParameter, 17 );
 };
 #endif

--- a/scripts/VTS/ANALYSIS.mscw_energy.sh
+++ b/scripts/VTS/ANALYSIS.mscw_energy.sh
@@ -18,7 +18,7 @@ if [ $# -lt 2 ]; then
 echo "
 MSCW_ENERGY data analysis: submit jobs from a simple run list
 
-ANALYSIS.mscw_energy.sh <table file> <runlist> [evndisp directory] [Rec ID] [output directory] [Model3D]
+ANALYSIS.mscw_energy.sh <table file> <runlist> [evndisp directory] [Rec ID] [output directory]
 
 required parameters:
 
@@ -42,8 +42,6 @@ optional parameters:
     [output directory]      directory where mscw.root files are written
                             default: <evndisp directory>
                             If RecID given: <evndisp directory>/RecID#
-
-    [Model3D]               set to 1 to switch on 3D model (default is off)
 
 --------------------------------------------------------------------------------
 "
@@ -74,7 +72,6 @@ elif [[ "$4" ]]; then
 else
     ODIR=$INPUTDIR
 fi
-[[ "$6" ]] && MODEL3D=$6 || MODEL3D=0
 
 # Read runlist
 if [ ! -f "$RLIST" ] ; then
@@ -123,8 +120,7 @@ do
     sed -e "s|TABLEFILE|$TABFILE|" \
         -e "s|RECONSTRUCTIONID|$ID|" \
         -e "s|OUTPUTDIRECTORY|$ODIR|" \
-        -e "s|EVNDISPFILE|$BFILE|" \
-        -e "s|USEMODEL3DMETHOD|$MODEL3D|" $SUBSCRIPT.sh > $FSCRIPT.sh
+        -e "s|EVNDISPFILE|$BFILE|" $SUBSCRIPT.sh > $FSCRIPT.sh
 
     chmod u+x $FSCRIPT.sh
     echo $FSCRIPT.sh

--- a/scripts/VTS/helper_scripts/ANALYSIS.mscw_energy_sub.sh
+++ b/scripts/VTS/helper_scripts/ANALYSIS.mscw_energy_sub.sh
@@ -9,7 +9,6 @@ TABFILE=TABLEFILE
 RECID=RECONSTRUCTIONID
 ODIR=OUTPUTDIRECTORY
 INFILE=EVNDISPFILE
-USEMODEL3D=USEMODEL3DMETHOD
 
 INDIR=`dirname $INFILE`
 BFILE=`basename $INFILE .root`
@@ -31,16 +30,11 @@ cp -f -v $INFILE $TEMPDIR
 
 MSCWDATAFILE="$ODIR/$BFILE.mscw.root"
 
-if [[ $USEMODEL3D == "1" ]]; then
-    MODEL3D="-model3d"
-    echo "using Model3D for direction and core values"
-fi
-
 MOPT="-arrayrecid=$RECID -writeReconstructedEventsOnly=1"
 MOPT="$MOPT -useMedian=0 -distance_energyCuts=1.3"
 
 # run mscw_energy
-$EVNDISPSYS/bin/mscw_energy -tablefile $TABFILE $MOPT -inputfile $TEMPDIR/$BFILE.root $MODEL3D &> $MSCWLOGFILE
+$EVNDISPSYS/bin/mscw_energy -tablefile $TABFILE $MOPT -inputfile $TEMPDIR/$BFILE.root &> $MSCWLOGFILE
 
 # move output file from scratch and clean up
 cp -f -v $TEMPDIR/$BFILE.mscw.root $MSCWDATAFILE

--- a/src/VEffectiveAreaCalculator.cpp
+++ b/src/VEffectiveAreaCalculator.cpp
@@ -496,7 +496,7 @@ vector< TProfile* > VEffectiveAreaCalculator::initializeHistogramsVectorHProfile
     
     for( unsigned int j = 0; j < fVMinAz.size(); j++ )
     {
-        sprintf( hname, "%s_%d_%d", iName.c_str(), i, j );
+        sprintf( hname, "%s_%u_%u", iName.c_str(), i, j );
         if( h )
         {
             iT_TProfile.push_back( ( TProfile* )h->Clone( hname ) );
@@ -943,10 +943,6 @@ bool VEffectiveAreaCalculator::initializeEffectiveAreasFromHistograms( TTree* iE
                         fZe.push_back( fMCZe[w] );
                         break;
                     }
-                }
-                if( fZe.size() > 0 )
-                {
-                    i_index_ze = fZe.size() - 1;
                 }
                 fZe.push_back( 10. );
                 i_index_ze = 0;
@@ -1485,7 +1481,7 @@ bool VEffectiveAreaCalculator::getMonteCarloSpectra( VEffectiveAreaCalculatorMCH
         {
             if( s < hVEmc.size() && i_az < hVEmc[s].size() )
             {
-                sprintf( hname, "hVEmc_%d_%d", s, i_az );
+                sprintf( hname, "hVEmc_%u_%u", s, i_az );
                 if( iMC_histo->getHistogram_Emc( i_az, s ) )
                 {
                     hVEmc[s][i_az] = ( TH1D* )iMC_histo->getHistogram_Emc( i_az, s )->Clone( hname );
@@ -1506,7 +1502,7 @@ bool VEffectiveAreaCalculator::getMonteCarloSpectra( VEffectiveAreaCalculatorMCH
             // profiles with spectral weights
             if( s < hVEmcSWeight.size() && i_az < hVEmcSWeight[s].size() )
             {
-                sprintf( hname, "hVEmcSWeight_%d_%d", s, i_az );
+                sprintf( hname, "hVEmcSWeight_%u_%u", s, i_az );
                 if( iMC_histo->getHistogram_EmcWeight( i_az, s ) )
                 {
                     hVEmcSWeight[s][i_az] = ( TProfile* )iMC_histo->getHistogram_EmcWeight( i_az, s )->Clone( hname );

--- a/src/VEffectiveAreaCalculator.cpp
+++ b/src/VEffectiveAreaCalculator.cpp
@@ -685,7 +685,14 @@ VEffectiveAreaCalculator::VEffectiveAreaCalculator( string iInputFile, double az
     }
 }
 
-
+/*
+ * get mean value between to azimuth angle
+ * taking into account the Eventdisplay azimuth
+ * definition 
+ *
+ * handles mix of neg/positive azimuth values
+ *
+ */
 float VEffectiveAreaCalculator::getAzMean( float azmin, float azmax )
 {
     // mean azimuth angle
@@ -729,7 +736,6 @@ vector< float > VEffectiveAreaCalculator::interpolate_effectiveArea( double iV, 
     
     return i_temp;
 }
-
 
 /*
  *
@@ -812,7 +818,6 @@ bool VEffectiveAreaCalculator::initializeEffectiveAreasFromHistograms( TTree* iE
         iEffArea->SetBranchAddress( "e_Rec_Res" , e_Rec_Res );
         iEffArea->SetBranchAddress( "e_Rec_Res_Err" , e_Rec_Res_Err );
     }
-
     // bias in energy reconstruction
     iEffArea->SetBranchAddress( "esys_rel", esys_rel );
     
@@ -926,7 +931,8 @@ bool VEffectiveAreaCalculator::initializeEffectiveAreasFromHistograms( TTree* iE
             i_ze_F = false;
             for( unsigned z = 0; z < fZe.size(); z++ )
             {
-                // this has to be a relatively large value due to wobble offsets up to 2.0 deg
+                // this has to be a relatively large value due
+                // to allowed wobble offsets up to 2.0 deg
                 if( fabs( fZe[z] - ze ) < 2.0 )
                 {
                     i_index_ze = z;
@@ -944,8 +950,6 @@ bool VEffectiveAreaCalculator::initializeEffectiveAreasFromHistograms( TTree* iE
                         break;
                     }
                 }
-                fZe.push_back( 10. );
-                i_index_ze = 0;
             }
             ///////////////////////////////////////////////////
             // wobble offset
@@ -973,7 +977,19 @@ bool VEffectiveAreaCalculator::initializeEffectiveAreasFromHistograms( TTree* iE
                 vector< double > itemp;
                 itemp.push_back( fWoff );
                 fEff_WobbleOffsets.push_back( itemp );
-                i_index_woff = fEff_WobbleOffsets[i_index_ze].size() - 1;
+                if( i_index_ze < fEff_WobbleOffsets.size() )
+                {
+                    i_index_woff = fEff_WobbleOffsets[i_index_ze].size() - 1;
+                }
+                else
+                {
+                     cout << "Error in ";
+                     cout << "VEffectiveAreaCalculator::initializeEffectiveAreasFromHistograms:";
+                     cout << " setting of wobble vector" << endl;
+                     cout << i_index_ze << " >= " << fEff_WobbleOffsets.size() << endl;
+                     exit( EXIT_FAILURE );
+                }
+
             }
             ///////////////////////////////////////////////////
             // noise level

--- a/src/VInstrumentResponseFunction.cpp
+++ b/src/VInstrumentResponseFunction.cpp
@@ -303,7 +303,6 @@ bool VInstrumentResponseFunction::fillResolutionGraphs( vector< vector< VInstrum
         {
             if( fIRFData[i][j] )
             {
-                cout << "\t" << i << "\t" << j << endl;
                 fIRFData[i][j]->terminate( fContainmentProbability );
             }
         }

--- a/src/VPlotRadialAcceptance.cpp
+++ b/src/VPlotRadialAcceptance.cpp
@@ -59,11 +59,12 @@ bool VPlotRadialAcceptance::openAcceptanceFile( string iFile, int iAzBin )
     //
     // Note that some of the histograms might not be available in the
     // radial acceptance file
-    cout << "reading acceptance histograms from " << fAcceptanceFile->GetName() << endl;
-    fAcceptanceHisto = ( TH1F* )fAcceptanceFile->Get( "hRadialAcceptance" );
+    cout << "reading acceptance histograms from ";
+    cout << fAcceptanceFile->GetName() << " (" << gDirectory->GetName() << ")" << endl;
+    fAcceptanceHisto = ( TH1F* )gDirectory->Get( "hRadialAcceptance" );
     if( !fAcceptanceHisto )
     {
-        fAcceptanceHisto = ( TH1F* )fAcceptanceFile->Get( "hAccZe_0" );
+        fAcceptanceHisto = ( TH1F* )gDirectory->Get( "hAccZe_0" );
         if( !fAcceptanceHisto )
         {
             cout << "VPlotRadialAcceptance::addAcceptanceFile: error finding acceptance histogram" << endl;
@@ -72,10 +73,10 @@ bool VPlotRadialAcceptance::openAcceptanceFile( string iFile, int iAzBin )
         }
     }
     // read acceptance fit function from file
-    fAcceptanceFunction = ( TF1* )fAcceptanceFile->Get( "fRadialAcceptance" );
+    fAcceptanceFunction = ( TF1* )gDirectory->Get( "fRadialAcceptance" );
     if( !fAcceptanceFunction )
     {
-        fAcceptanceFunction = ( TF1* )fAcceptanceFile->Get( "fAccZe_0" );
+        fAcceptanceFunction = ( TF1* )gDirectory->Get( "fAccZe_0" );
         if( !fAcceptanceFunction )
         {
             cout << "VPlotRadialAcceptance::addAcceptanceFile: error finding acceptance fit function" << endl;
@@ -85,7 +86,7 @@ bool VPlotRadialAcceptance::openAcceptanceFile( string iFile, int iAzBin )
     }
     sprintf( hname, "hXYAccTotDeRot" );
     fAcceptanceHisto2D_derot_normalized = false;
-    fAcceptanceHisto2D_derot = ( TH2F* )fAcceptanceFile->Get( hname );
+    fAcceptanceHisto2D_derot = ( TH2F* )gDirectory->Get( hname );
     
     sprintf( hname, "hXYaccTot" );
     fAcceptanceHisto2D_rot = ( TH2F* )fAcceptanceFile->Get( hname );
@@ -99,21 +100,21 @@ bool VPlotRadialAcceptance::openAcceptanceFile( string iFile, int iAzBin )
     for( int i = 0; i < 16; i++ )
     {
         sprintf( hname, "hAccPhi_%d", i );
-        fAcceptancePhiHisto.push_back( ( TH1F* )fAcceptanceFile->Get( hname ) );
+        fAcceptancePhiHisto.push_back( ( TH1F* )gDirectory->Get( hname ) );
         sprintf( hname, "fAccPhi_%d", i );
-        fAcceptancePhiFitFunction.push_back( ( TF1* )fAcceptanceFile->Get( hname ) );
+        fAcceptancePhiFitFunction.push_back( ( TF1* )gDirectory->Get( hname ) );
         sprintf( hname, "hAccPhiDerot_%d", i );
-        fAcceptancePhiHistoDeRot.push_back( ( TH1F* )fAcceptanceFile->Get( hname ) );
+        fAcceptancePhiHistoDeRot.push_back( ( TH1F* )gDirectory->Get( hname ) );
         sprintf( hname, "fAccPhiDerot_%d", i );
-        fAcceptancePhiFitFunctionDeRot.push_back( ( TF1* )fAcceptanceFile->Get( hname ) );
+        fAcceptancePhiFitFunctionDeRot.push_back( ( TF1* )gDirectory->Get( hname ) );
     }
     // read AZ distributions
-    hPhiDist = ( TH1F* )fAcceptanceFile->Get( "hPhiDist" );
+    hPhiDist = ( TH1F* )gDirectory->Get( "hPhiDist" );
     if( hPhiDist )
     {
         hPhiDist->Rebin( 5 );
     }
-    hPhiDistDeRot = ( TH1F* )fAcceptanceFile->Get( "hPhiDistDeRot" );
+    hPhiDistDeRot = ( TH1F* )gDirectory->Get( "hPhiDistDeRot" );
     if( hPhiDistDeRot )
     {
         hPhiDistDeRot->Rebin( 5 );

--- a/src/VRadialAcceptance.cpp
+++ b/src/VRadialAcceptance.cpp
@@ -127,7 +127,6 @@ VRadialAcceptance::VRadialAcceptance( VGammaHadronCuts* icuts, VAnaSumRunParamet
     {
         fCut_CameraFiducialSize_max = iMaxDistanceAllowed;
         fCuts->fCut_CameraFiducialSize_max = iMaxDistanceAllowed;
-        
     }
     else
     {
@@ -260,49 +259,6 @@ VRadialAcceptance::VRadialAcceptance( VGammaHadronCuts* icuts, VAnaSumRunParamet
     hXYAccTotDeRot->Sumw2();
     hList->Add( hXYAccTotDeRot );
     histListProductionIO->Add( hXYAccTotDeRot );
-    
-    // azimuth dependent radial acceptance histograms
-    fPhiMin.clear();
-    fPhiMax.clear();
-    /*	fPhiMin.push_back( 135.0 );
-    	fPhiMax.push_back( -165.0 );
-    	fPhiMin.push_back( 150.0 );
-    	fPhiMax.push_back( -150.0 );
-    	fPhiMin.push_back( -180. );
-    	fPhiMax.push_back( -120. );
-    	for( int i = 0; i < 13; i++ )
-    	{
-    		fPhiMin.push_back( fPhiMin.back() + 22.5 );
-    		fPhiMax.push_back( fPhiMax.back() + 22.5 );
-    	} */
-    for( unsigned int i = 0; i < fPhiMin.size(); i++ )
-    {
-        // camera coordinates
-        sprintf( hname, "hAccPhi_%d", i );
-        sprintf( htitle, "%.0f < Phi < %.0f", fPhiMin[i], fPhiMax[i] );
-        hAccPhi.push_back( new TH1F( hname, htitle, nxybin, 0., xymax ) );
-        hAccPhi.back()->SetXTitle( "distance to camera center [deg]" );
-        hAccPhi.back()->SetYTitle( "relative rate" );
-        hAccPhi.back()->SetMarkerSize( 2 );
-        hAccPhi.back()->SetLineWidth( 2 );
-        hAccPhi.back()->Sumw2();
-        hList->Add( hAccPhi.back() );
-        hListNormalizeHistograms->Add( hAccPhi.back() );
-        hListFitHistograms->Add( hAccPhi.back() );
-        // derotated camera coordinates
-        sprintf( hname, "hAccPhiDerot_%d", i );
-        sprintf( htitle, "%.0f < Phi < %.0f (derot)", fPhiMin[i], fPhiMax[i] );
-        hAccPhiDerot.push_back( new TH1F( hname, htitle, nxybin, 0., xymax ) );
-        hAccPhiDerot.back()->SetXTitle( "distance to camera center [deg]" );
-        hAccPhiDerot.back()->SetYTitle( "relative rate" );
-        hAccPhiDerot.back()->SetMarkerSize( 2 );
-        hAccPhiDerot.back()->SetLineWidth( 2 );
-        hAccPhiDerot.back()->Sumw2();
-        hList->Add( hAccPhiDerot.back() );
-        hListNormalizeHistograms->Add( hAccPhiDerot.back() );
-        hListFitHistograms->Add( hAccPhiDerot.back() );
-    }
-    
     
     // for PhiDependentSlice hists
     phi_minphi = 0.0 ;
@@ -619,7 +575,8 @@ int VRadialAcceptance::fillAcceptanceFromData( CData* iData, int entry, double x
     bool bPassed = false;
     
     // apply some basic quality cuts
-    if( fCuts->applyInsideFiducialAreaCut() && fCuts->applyStereoQualityCuts( fEnergyReconstructionMethod, false, entry, true ) )
+    if( fCuts->applyInsideFiducialAreaCut()
+      && fCuts->applyStereoQualityCuts( fEnergyReconstructionMethod, false, entry, true ) )
     {
         // gamma/hadron cuts
         if( !fCuts->isGamma( entry, false ) )
@@ -703,62 +660,6 @@ int VRadialAcceptance::fillAcceptanceFromData( CData* iData, int entry, double x
         
         // fill azimuth angle dependend histograms (camera coordinates)
         hPhiDist->Fill( i_Phi * TMath::RadToDeg() );
-        
-        for( unsigned int j = 0; j < fPhiMin.size(); j++ )
-        {
-            bFill = false;
-            if( i_Phi > fPhiMin[j] && i_Phi < fPhiMax[j] )
-            {
-                bFill = true;
-            }
-            else
-            {
-                if( fPhiMin[j] > fPhiMax[j] )
-                {
-                    if( i_Phi < fPhiMin[j] && i_Phi > fPhiMax[j] )
-                    {
-                        bFill = false;
-                    }
-                    else
-                    {
-                        bFill = true;
-                    }
-                }
-            }
-            if( bFill && idist > 0. )
-            {
-                hAccPhi[j]->Fill( idist );
-            }
-        }
-        // fill azimuth angle dependend histograms (derotated camera coordinates)
-        i_Phi = atan2( y_rotJ2000, x_rotJ2000 ) * TMath::RadToDeg();
-        for( unsigned int j = 0; j < fPhiMin.size(); j++ )
-        {
-            bool bFill = false;
-            if( i_Phi > fPhiMin[j] && i_Phi < fPhiMax[j] )
-            {
-                bFill = true;
-            }
-            else
-            {
-                if( fPhiMin[j] > fPhiMax[j] )
-                {
-                    if( i_Phi < fPhiMin[j] && i_Phi > fPhiMax[j] )
-                    {
-                        bFill = false;
-                    }
-                    else
-                    {
-                        bFill = true;
-                    }
-                }
-            }
-            if( bFill &&  idist > 0. )
-            {
-                hAccPhiDerot[j]->Fill( idist );
-            }
-        }
-        
     }
     
     if( bPassed )
@@ -777,11 +678,21 @@ int VRadialAcceptance::fillAcceptanceFromData( CData* iData, int entry, double x
 */
 bool VRadialAcceptance::terminate( TDirectory* iDirectory )
 {
-    if( !iDirectory->cd() )
+    if( !iDirectory || !iDirectory->cd() )
     {
         cout << "VRadialAcceptance::terminate() error accessing directory  " << iDirectory->GetName() << endl;
         exit( EXIT_FAILURE );
     }
+    cout << "Starting scaling and fitting ";
+    if( strlen( iDirectory->GetTitle() ) )
+    {
+         cout << "(" << iDirectory->GetName() << ", " << iDirectory->GetTitle() << ")";
+    }
+    else
+    {
+         cout << "(az average histograms)";
+    }
+    cout << endl;
     /////////////////////////////////////
     // normalize radial acceptance histograms
     // scale everything to mean value of first three bins
@@ -803,8 +714,12 @@ bool VRadialAcceptance::terminate( TDirectory* iDirectory )
             i_normBin = 0.;
             if( i == 0 && h->GetEntries() > 0 )
             {
-                cout << "VRadialAcceptance::terminate: scaling histograms to bins ";
+                cout << "\tscaling acceptance  histograms to bins ";
                 cout << fAccZeFitMinBin << " to " << fAccZeFitMaxBin << endl;
+            }
+            else if( i == 0 )
+            {
+                cout << "\tno entries in histograms, skipping..." << endl << endl;
             }
             for( unsigned int j = fAccZeFitMinBin; j < fAccZeFitMaxBin; j++ )
             {
@@ -868,7 +783,7 @@ bool VRadialAcceptance::terminate( TDirectory* iDirectory )
         }
         
         // fit the data and fill histograms
-        cout << "fitting acceptance curves (" << h->GetName() << ") ..." << endl << endl;
+        cout << "\tfitting acceptance curves (" << h->GetName() << ") ..." << endl;
         double i_eval = 0.;
         gErrorIgnoreLevel = 5000;
         hfit->Fit( ffit, "0REMQ" );
@@ -904,9 +819,10 @@ bool VRadialAcceptance::terminate( TDirectory* iDirectory )
     // write total number of entries in each histogram (ze) to screen
     if( fRadialAcceptance->GetEntries() > 0. )
     {
-        cout << "total number of events in radial acceptance histogram: ";
+        cout << "\ttotal number of events in radial acceptance histogram: ";
         cout << fRadialAcceptance->GetEntries() << endl;
-        cout << endl << "writing acceptance curves to following directory: " << iDirectory->GetName() << endl;
+        cout << "\twriting acceptance curves to following directory: " << iDirectory->GetName();
+        cout << endl << endl;
     }
     
     if( fproduction_shortIO )
@@ -1363,9 +1279,18 @@ bool VRadialAcceptance::correctRadialAcceptancesForExclusionRegions( TDirectory*
     /////////////////////////////////////////////
     // fill a 2D map and the 1D area map taking
     // exclusion regions into account
-    cout << "2D filling of acceptance ratios" << endl;
+    cout << "2D filling of acceptance ratios taking exclusion regions into account ";
+    if( strlen( iDirectory->GetTitle() ) )
+    {
+         cout << "(" << iDirectory->GetName() << ", " << iDirectory->GetTitle() << "):";
+    }
+    else
+    {
+         cout << "(az average histograms):";
+    }
+    cout << endl;
     double neventssim = ( double )( hAreaExcluded2D[ifocus]->GetNbinsX() * hAreaExcluded2D[ifocus]->GetNbinsY() );
-    cout << "\t neventssim = " << neventssim << endl;
+    cout << "\t number of simulations " << neventssim << endl;
     cout << "\t nxbins = " << hAreaExcluded2D[ifocus]->GetNbinsX() << endl ;
     cout << "\t nybins = " << hAreaExcluded2D[ifocus]->GetNbinsY() << endl ;
     int nfilled = 0 ;
@@ -1437,7 +1362,6 @@ int VRadialAcceptance::calculateAverageRadialAcceptanceCurveFromRuns( TDirectory
     // add up all runwise radial acceptance curves
     while( TH1F* h = ( TH1F* )next() )
     {
-    
         sprintf( numberstring, "%s_", "hRadialAcceptance_perRun" );
         if( strstr( h->GetName(), numberstring ) != NULL )
         {

--- a/src/makeRadialAcceptance.cpp
+++ b/src/makeRadialAcceptance.cpp
@@ -69,7 +69,7 @@ int main( int argc, char* argv[] )
     ///////////////////////////////////////////
     // print general stuff and version numbers
     cout << endl;
-    cout << "makeRadialAcceptance " << fRunPara->getEVNDISP_VERSION() << endl << endl;
+    cout << "makeRadialAcceptance (" << fRunPara->getEVNDISP_VERSION() << ")" << endl << endl;
     cout << "determine radial acceptance from off events (after cuts)" << endl;
     cout << endl;
     
@@ -82,8 +82,12 @@ int main( int argc, char* argv[] )
     // (note that exclusion regions per run are added later)
     if( exclusionregionfile.size() > 0 )
     {
-        cout << "reading exclusion regions from " << exclusionregionfile << endl;
+        cout << "Reading exclusion regions from " << exclusionregionfile << endl;
         fRunPara->readRunParameter( exclusionregionfile, true );
+    }
+    else
+    {
+       cout << "No exclusion regions defined" << endl;
     }
     
     ///////////////////////////////////////////
@@ -163,7 +167,17 @@ int main( int argc, char* argv[] )
         cout << "exiting..." << endl;
         exit( EXIT_FAILURE );
     }
-    
+    cout << "Max distance of events to camera centre: " << fMaxDistanceAllowed << " [deg]" << endl;
+    cout << "Instrument epoch is " << fInstrumentEpoch << endl;
+    cout << "Telescopes to analyse: " << teltoanastring << endl;
+    if( production_shortIO )
+    {
+        cout << "Write histograms required for production only" << endl;
+    }
+    else
+    {
+        cout << "Write long list of histograms" << endl;
+    }
     cout << "total number of files to read: " << fRunPara->fRunList.size() << endl;
     
     char ifile[1800];
@@ -174,7 +188,7 @@ int main( int argc, char* argv[] )
     if( fo->IsZombie() )
     {
         cout << "makeRadialAcceptances: error opening output file " << outfile << endl;
-        return 0;
+        exit( EXIT_FAILURE );
     }
     cout << endl << "open output file for acceptance curves: " << fo->GetName() << endl;
     TDirectory* facc_dir = ( TDirectory* )fo;
@@ -193,8 +207,9 @@ int main( int argc, char* argv[] )
         }
         else
         {
-            cout << "Error, directory specified by makeRadialAcceptance -w option '" << histdir << "' does not exist, exiting..." << endl;
-            return 0;
+            cout << "Error, directory specified by makeRadialAcceptance -w option '";
+            cout << histdir << "' does not exist, exiting..." << endl;
+            exit( EXIT_FAILURE );
         }
     }
     
@@ -232,7 +247,7 @@ int main( int argc, char* argv[] )
             facc_az_dir.back()->cd();
             facc_az.push_back( new VRadialAcceptance( fCuts, fRunPara ) );
             facc_az.back()->setAzCut( iAz_min[i], iAz_max[i] );
-            cout << "initializing AZ dependend radial acceptance class for ";
+            cout << "initializing azimuth dependend radial acceptance class for ";
             cout << iAz_min[i] << " < az <= " <<   iAz_max[i] << endl;
         }
     }
@@ -261,9 +276,9 @@ int main( int argc, char* argv[] )
         if( !d )
         {
             cout << "makeRadialAcceptance: no data tree defined: run " << fRunPara->fRunList[i].fRunOff << endl;
-            return 0;
+            exit( EXIT_FAILURE );
         }
-        // set reconstruction type (e.g. GEO, DISP, FROGS, ...
+        // set reconstruction type (e.g. GEO, DISP, ...)
         d->setReconstructionType( fCuts->fReconstructionType );
         
         /////////////////////////////////////
@@ -328,11 +343,20 @@ int main( int argc, char* argv[] )
                 -1.*fRunPara->fRunList[i].fWobbleWest,    // require wobble EAST
                 raJ2000_deg, decJ2000_deg );
                 
-        cout << "\tcamera centre at (ra,dec) J2000 : ( " << raJ2000_deg << ", " << decJ2000_deg << ")" << endl;
+        cout << "Camera centre at (ra,dec) J2000 : ( " << raJ2000_deg << ", " << decJ2000_deg << ")" << endl;
         ////////////////////////////////////////////
         // initialize exclusion regions
+
+        // exclude source direction
+        if( fRunPara->getExclusionRegions() )
+        {
+              fRunPara->getExclusionRegions()->addExclusionRegion( -1., -1.,
+                                       fRunPara->fRunList[i].fTargetRAJ2000, fRunPara->fRunList[i].fTargetDecJ2000,
+                                       0.25, 0.25, 0., "on source" );
+        }
         if( exclusionregionfile.size() > 0 )
         {
+            cout << "Exclusion regions: " << endl;
             double iMax = fMaxDistanceAllowed * 1.3;
             VStarCatalogue iStarCatalogue;
             iStarCatalogue.init( iMJD, fRunPara->getStarCatalogue() );
@@ -342,6 +366,13 @@ int main( int argc, char* argv[] )
                                                   raJ2000_deg, decJ2000_deg,
                                                   raJ2000_deg, decJ2000_deg );
             facc->setRegionToExcludeAcceptance( fRunPara->getExclusionRegions( i ) );
+            for( unsigned int a = 0; a < facc_az.size(); a++ )
+            {
+                 if( facc_az[a] )
+                 {
+                      facc_az[a]->setRegionToExcludeAcceptance( fRunPara->getExclusionRegions( i ) );
+                 }
+            }
         }
         
         if( fCuts )
@@ -382,7 +413,6 @@ int main( int argc, char* argv[] )
                 continue;
             }
             
-            
             ////////////////////////////////
             // fill acceptances
             
@@ -407,6 +437,17 @@ int main( int argc, char* argv[] )
         
         fDataFile.Close();
         facc->correctRadialAcceptancesForExclusionRegions( facc_dir, fRunPara->fRunList[i].fRunOff );
+        for( unsigned int a = 0; a < facc_az.size(); a++ )
+        {
+             if( facc_az[a] )
+             {
+                  if( facc_az[a] )
+                  {
+                      facc_az[a]->correctRadialAcceptancesForExclusionRegions( facc_az_dir[a],
+                                                                               fRunPara->fRunList[i].fRunOff );
+                  }
+             }
+        }
     }
     
     /////////////////////////////////////////
@@ -418,6 +459,7 @@ int main( int argc, char* argv[] )
     {
         if( facc_az[a] )
         {
+            facc_az[a]->calculateAverageRadialAcceptanceCurveFromRuns( facc_az_dir[a] );
             facc_az[a]->terminate( facc_az_dir[a] );
         }
     }
@@ -520,21 +562,19 @@ int parseOptions( int argc, char* argv[] )
                 break;
             case 'c':
                 cutfilename = optarg;
-                cout << "Cut File Name is " << cutfilename << endl;
+                cout << "Cuts are taken from " << cutfilename << endl;
                 if( cutfilename == "IGNOREEFFECTIVEAREA" )
                 {
                      cout << "error: cannot read cuts (IGNOREEFFECTIVEAREA given)" << endl;
                      cout << "exiting..." << endl;
-                     exit( 0 );
+                     exit( EXIT_FAILURE );
                 }  
                 break;
             case 'm':
                 fMaxDistanceAllowed = atof( optarg );
-                cout << "Maximum allowed distance from camera centre: " << fMaxDistanceAllowed << endl;
                 break;
             case 'i':
                 fInstrumentEpoch = optarg;
-                cout << "Instrument epoch is " << fInstrumentEpoch << endl;
                 break;
             case 'e':
                 entries = ( int )atoi( optarg );
@@ -545,14 +585,11 @@ int parseOptions( int argc, char* argv[] )
                 break;
             case 't':
                 teltoanastring = optarg;
-                cout << "Telescopes to analyse: " << teltoanastring << endl;
                 break;
             case 'p':
                 production_shortIO = ( int )atoi( optarg );
-                cout << "Telescopes to analyse: " << teltoanastring << endl;
             case 'f':
                 exclusionregionfile = optarg;
-                cout << "File with exclusion regions: " << exclusionregionfile << endl;
                 break;
             case '?':
                 break;

--- a/src/makeRadialAcceptance.cpp
+++ b/src/makeRadialAcceptance.cpp
@@ -42,6 +42,8 @@ bool   production_shortIO = false;
 // calculations (must be given in an anasum-style
 // runparameter file
 string exclusionregionfile = "";
+// target region excluded
+bool fRemoveTargetRegionFromAcceptanceFilling = true;
 
 
 ////////////////////////////////////////////////////////////////////
@@ -88,6 +90,10 @@ int main( int argc, char* argv[] )
     else
     {
        cout << "No exclusion regions defined" << endl;
+    }
+    if( fRemoveTargetRegionFromAcceptanceFilling )
+    {
+       cout << "Removing target region from radial acceptance filling" << endl;
     }
     
     ///////////////////////////////////////////
@@ -494,10 +500,11 @@ int parseOptions( int argc, char* argv[] )
             {"writehists", optional_argument, 0, 'w'},
             {"teltoana", required_argument, 0, 't'},
             {"productionIO", required_argument, 0, 'p'},
+            {"--remove_target", required_argument, 0, 'r'},
             {0, 0, 0, 0}
         };
         int option_index = 0;
-        int c = getopt_long( argc, argv, "ht:s:f:p:l:e:m:o:i:d:n:c:w:t:", long_options, &option_index );
+        int c = getopt_long( argc, argv, "ht:s:f:p:l:e:m:r:o:i:d:n:c:w:t:", long_options, &option_index );
         if( optopt != 0 )
         {
             cout << "error: unknown option" << endl;
@@ -538,6 +545,7 @@ int parseOptions( int argc, char* argv[] )
                 cout << "-e --entries [number of entries]" << endl;
                 cout << "-m --maxdist [max distance from camera centre (deg)]" << endl;
                 cout << "-w --writehists [directory]" << endl ;
+                cout << "-r --remove_target region from acceptance filling [default=true]" << endl;
                 cout << "-t --teltoana <telescopes>" << endl;
                 cout << "-p --productionIO [0/1] " << endl;
                 cout << "-f --exclusionregionfile [file with exclusion regions]" << endl;
@@ -590,6 +598,9 @@ int parseOptions( int argc, char* argv[] )
                 production_shortIO = ( int )atoi( optarg );
             case 'f':
                 exclusionregionfile = optarg;
+                break;
+            case 'r':
+                fRemoveTargetRegionFromAcceptanceFilling = (bool)atoi(optarg);
                 break;
             case '?':
                 break;


### PR DESCRIPTION
Fixed several problems regarding the calculation of radial acceptance curves:

- exclusions regions are now taken into account
- central region exclusions (new option '-r'; default = on)
- printout of successful fits


Fixed also a problem for the reading of effective areas (must have been a debug leftover, as this code was not in v480)