### PR TITLE
Disp opt

### DIFF
--- a/inc/VDispAnalyzer.h
+++ b/inc/VDispAnalyzer.h
@@ -136,7 +136,8 @@ class VDispAnalyzer
         float evaluate( float iWidth, float iLength, float iAsymm, float iDist,
                         float iSize, float iPedvar, float itgrad, float iLoss,
                         float icen_x, float icen_y, float xoff_4, float yoff_4, ULong64_t iTelType,
-                        float iZe, float iAz, float iRcore = -99., float iFui = -1., bool b2D = true );
+                        float iZe, float iAz, float iRcore = -99., float iFui = -1., float iNtubes = -1.,
+                        bool b2D = true );
         float getAngDiff()
         {
             return f_angdiff;

--- a/inc/VTMVADispAnalyzer.h
+++ b/inc/VTMVADispAnalyzer.h
@@ -33,6 +33,7 @@ class VTMVADispAnalyzer
         float fLength;
         float fWoL;
         float fSize;
+        float fNtubes;
         float fPedvar;
         float fTGrad;
         float fZe;
@@ -55,7 +56,7 @@ class VTMVADispAnalyzer
         float evaluate( float iWidth, float iLength, float iSize, float iAsymm, float iLoss,
                         float iTGrad, float icen_x, float icen_y, float xoff_4, float yoff_4,
                         ULong64_t iTelType, float iZe, float iAz, float iRcore,
-                        float iEHeight = -1., float iDist = -1., float iFui = -1. );
+                        float iEHeight = -1., float iDist = -1., float iFui = -1., float iNtubes = -1 );
         bool isZombie()
         {
             return bZombie;

--- a/inc/VTableLookupDataHandler.h
+++ b/inc/VTableLookupDataHandler.h
@@ -283,6 +283,7 @@ class VTableLookupDataHandler
         int    fntubes_short[VDST_MAXTELESCOPES];
         float  fdist_short[VDST_MAXTELESCOPES];
         float  fwidth_short[VDST_MAXTELESCOPES];
+        float  fasym_short[VDST_MAXTELESCOPES];
         float  flength_short[VDST_MAXTELESCOPES];
         float  floss_short[VDST_MAXTELESCOPES];
         float  ffui_short[VDST_MAXTELESCOPES];
@@ -290,6 +291,7 @@ class VTableLookupDataHandler
         float  fcross_short[VDST_MAXTELESCOPES];
         float  fcrossO_short[VDST_MAXTELESCOPES];
         float  ftgrad_x_short[VDST_MAXTELESCOPES];
+        int    fFitstat_short[VDST_MAXTELESCOPES];
         double ffrogs_goodness_telType[VDST_MAXTELESCOPES];
         vector<float>* ffrogs_goodness_vector;
         

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -141,7 +141,7 @@ void VDispAnalyzer::terminate()
 float VDispAnalyzer::evaluate( float iWidth, float iLength, float iAsymm, float iDist, float iSize,
                                float iPedvar, float iTGrad, float iLoss, float icen_x, float icen_y,
                                float xoff_4, float yoff_4, ULong64_t iTelType,
-                               float iZe, float iAz, float iRcore, float iFui, bool b2D )
+                               float iZe, float iAz, float iRcore, float iFui, float iNtubes, bool b2D )
 {
     f_disp = -99.;
     
@@ -157,7 +157,7 @@ float VDispAnalyzer::evaluate( float iWidth, float iLength, float iAsymm, float 
     {
         f_disp = fTMVADispAnalyzer->evaluate( iWidth, iLength, iSize, iAsymm, iLoss, iTGrad,
                                               icen_x, icen_y, xoff_4, yoff_4, iTelType,
-                                              iZe, iAz, iRcore, -1., iDist, iFui );
+                                              iZe, iAz, iRcore, -1., iDist, iFui, iNtubes );
     }
     return f_disp;
     
@@ -664,17 +664,17 @@ void VDispAnalyzer::calculateMeanDirection( unsigned int i_ntel,
                              ( float )img_cen_x[i], ( float )img_cen_y[i],
                              ( float )xoff_4, ( float )yoff_4, iTelType[i],
                              ( float )( 90. - iArrayElevation ), ( float )iArrayAzimuth,
-                             -99., ( float )img_fui[i] );
+                             -99., ( float )img_fui[i], ( float )img_ntubes[i] );
             // unsuccessful disp estimation - ignore image
             if( disp < -98. )
             {
                 continue;
             }
             // use time gradient to get right directory for image
-            if( img_tgrad[i] < 0. )
+/* TMPTMP            if( img_tgrad[i] < 0. )
             {
                 disp *= -1.;
-            }
+            } */
             v_disp.push_back( disp );
             
             // use estimated uncertainty on disp direction reconstruction as
@@ -782,7 +782,8 @@ void VDispAnalyzer::calculateExpectedDirectionError( unsigned int i_ntel,
                                          ( float )img_cen_x[i], ( float )img_cen_y[i],
                                          ( float )xoff_4, ( float )yoff_4, iTelType[i],
                                          ( float )( 90. - iArrayElevation ), ( float )iArrayAzimuth,
-                                         -99., ( float )img_fui[i] );
+                                         -99., ( float )img_fui[i], ( float )img_ntubes[i] );
+            fdisp_error_T[i] = TMath::Power( 10., fdisp_error_T[i] );
         }
     }
 }
@@ -902,7 +903,7 @@ void VDispAnalyzer::calculateEnergies( unsigned int i_ntel,
                                     ( float )( 90. - iArrayElevation ), ( float )iArrayAzimuth,
                                     ( float )iRcore[i], ( float )iEHeight,
                                     ( float )sqrt( img_cen_x[i] * img_cen_x[i] + img_cen_y[i] * img_cen_y[i] ),
-                                    ( float )img_fui[i] );
+                                    ( float )img_fui[i], ( float )img_ntubes[i] );
                                     
             // dispEnergy is trained as log10(MCe0) in GeV
             if( fdisp_energy_T[i] > -98. )
@@ -1141,7 +1142,7 @@ void VDispAnalyzer::calculateCore( unsigned int i_ntel,
                                   ( float )xoff_4, ( float )yoff_4, ( ULong64_t )iTelType[i],
                                   ( float )( 90. - iArrayElevation ), ( float )iArrayAzimuth,
                                   ( float )iRcore[i], -1., ( float )sqrt( img_cen_x[i] * img_cen_x[i] + img_cen_y[i] * img_cen_y[i] ),
-                                  ( float )img_fui[i] );
+                                  ( float )img_fui[i], ( float )img_ntubes[i] );
         }
         else
         {

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -665,16 +665,15 @@ void VDispAnalyzer::calculateMeanDirection( unsigned int i_ntel,
                              ( float )xoff_4, ( float )yoff_4, iTelType[i],
                              ( float )( 90. - iArrayElevation ), ( float )iArrayAzimuth,
                              -99., ( float )img_fui[i], ( float )img_ntubes[i] );
-            // unsuccessful disp estimation - ignore image
             if( disp < -98. )
             {
                 continue;
             }
             // use time gradient to get right directory for image
-/* TMPTMP            if( img_tgrad[i] < 0. )
+            if( img_tgrad[i] < 0. )
             {
                 disp *= -1.;
-            } */
+            }
             v_disp.push_back( disp );
             
             // use estimated uncertainty on disp direction reconstruction as

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -782,7 +782,6 @@ void VDispAnalyzer::calculateExpectedDirectionError( unsigned int i_ntel,
                                          ( float )xoff_4, ( float )yoff_4, iTelType[i],
                                          ( float )( 90. - iArrayElevation ), ( float )iArrayAzimuth,
                                          -99., ( float )img_fui[i], ( float )img_ntubes[i] );
-            fdisp_error_T[i] = TMath::Power( 10., fdisp_error_T[i] );
         }
     }
 }

--- a/src/VTMVADispAnalyzer.cpp
+++ b/src/VTMVADispAnalyzer.cpp
@@ -127,12 +127,11 @@ VTMVADispAnalyzer::VTMVADispAnalyzer( string iFile, vector<ULong64_t> iTelTypeLi
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "length", &fLength );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "wol", &fWoL );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "size", &fSize );
-        fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "ntubes", &fNtubes);
         // ASTRI telescopes are without timing information
         // tgrad_x is therefore ignored
         if( fTelescopeTypeList[i] != 201511619 )
         {
-            fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "tgrad_x", &fTGrad );
+            fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "tgrad_x*tgrad_x", &fTGrad );
         }
         // cross variable should be on this spot
         if( !iSingleTelescopeAnalysis )
@@ -209,7 +208,7 @@ float VTMVADispAnalyzer::evaluate( float iWidth, float iLength, float iSize, flo
         return -99.;
     }
     fNtubes = iNtubes;
-    fTGrad = iTGrad;
+    fTGrad = iTGrad * iTGrad;
     fZe = iZe;
     fAz = iAz;
     // %%@^#%!@(#

--- a/src/VTMVADispAnalyzer.cpp
+++ b/src/VTMVADispAnalyzer.cpp
@@ -22,6 +22,7 @@ VTMVADispAnalyzer::VTMVADispAnalyzer( string iFile, vector<ULong64_t> iTelTypeLi
     fLength = 0.;
     fWoL = 0.;
     fSize = 0.;
+    fNtubes = 0.;
     fPedvar = 0.;
     fAsymm = 0.;
     fTGrad = 0.;
@@ -44,6 +45,12 @@ VTMVADispAnalyzer::VTMVADispAnalyzer( string iFile, vector<ULong64_t> iTelTypeLi
     float iMCycore = 0.;
     float iMCrcore = 0.;
     float iNImages = 0.;
+    float cen_x = 0;
+    float cen_y = 0;
+    float cosphi = 0.;
+    float sinphi = 0.;
+    float temp1 = 0.;
+    float temp2 = 0.;
     
     // list of telescope types: required to selected correct BDT weight file
     fTelescopeTypeList = iTelTypeList;
@@ -120,11 +127,12 @@ VTMVADispAnalyzer::VTMVADispAnalyzer( string iFile, vector<ULong64_t> iTelTypeLi
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "length", &fLength );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "wol", &fWoL );
         fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "size", &fSize );
+        fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "ntubes", &fNtubes);
         // ASTRI telescopes are without timing information
         // tgrad_x is therefore ignored
         if( fTelescopeTypeList[i] != 201511619 )
         {
-            fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "tgrad_x*tgrad_x", &fTGrad );
+            fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "tgrad_x", &fTGrad );
         }
         // cross variable should be on this spot
         if( !iSingleTelescopeAnalysis )
@@ -141,6 +149,10 @@ VTMVADispAnalyzer::VTMVADispAnalyzer( string iFile, vector<ULong64_t> iTelTypeLi
             fTMVAReader[fTelescopeTypeList[i]]->AddVariable( "Rcore", &fRcore );
         }
         // spectators
+        fTMVAReader[fTelescopeTypeList[i]]->AddSpectator( "cen_x", &cen_x );
+        fTMVAReader[fTelescopeTypeList[i]]->AddSpectator( "cen_y", &cen_y );
+        fTMVAReader[fTelescopeTypeList[i]]->AddSpectator( "cosphi", &cosphi);
+        fTMVAReader[fTelescopeTypeList[i]]->AddSpectator( "sinphi", &sinphi);
         fTMVAReader[fTelescopeTypeList[i]]->AddSpectator( "MCe0", &iMCe0 );
         fTMVAReader[fTelescopeTypeList[i]]->AddSpectator( "MCxoff", &iMCxoff );
         fTMVAReader[fTelescopeTypeList[i]]->AddSpectator( "MCyoff", &iMCyoff );
@@ -148,6 +160,16 @@ VTMVADispAnalyzer::VTMVADispAnalyzer( string iFile, vector<ULong64_t> iTelTypeLi
         fTMVAReader[fTelescopeTypeList[i]]->AddSpectator( "MCycore", &iMCycore );
         fTMVAReader[fTelescopeTypeList[i]]->AddSpectator( "MCrcore", &iMCrcore );
         fTMVAReader[fTelescopeTypeList[i]]->AddSpectator( "NImages", &iNImages );
+        if( fDispType == "BDTDisp" )
+        {
+            fTMVAReader[fTelescopeTypeList[i]]->AddSpectator( "dispError", &temp2 );
+            fTMVAReader[fTelescopeTypeList[i]]->AddSpectator( "dispPhi", &temp1 );
+        }
+        else if( fDispType == "BDTDispError" )
+        {
+            fTMVAReader[fTelescopeTypeList[i]]->AddSpectator( "disp", &temp2 );
+            fTMVAReader[fTelescopeTypeList[i]]->AddSpectator( "dispPhi", &temp1 );
+        }
         
         if( !fTMVAReader[fTelescopeTypeList[i]]->BookMVA( "BDTDisp", iFileName.str().c_str() ) )
         {
@@ -166,7 +188,7 @@ VTMVADispAnalyzer::VTMVADispAnalyzer( string iFile, vector<ULong64_t> iTelTypeLi
 */
 float VTMVADispAnalyzer::evaluate( float iWidth, float iLength, float iSize, float iAsymm, float iLoss, float iTGrad,
                                    float icen_x, float icen_y, float xoff_4, float yoff_4, ULong64_t iTelType,
-                                   float iZe, float iAz, float iRcore, float iEHeight, float iDist, float iFui )
+                                   float iZe, float iAz, float iRcore, float iEHeight, float iDist, float iFui, float iNtubes )
 {
     fWidth = iWidth;
     fLength = iLength;
@@ -186,7 +208,8 @@ float VTMVADispAnalyzer::evaluate( float iWidth, float iLength, float iSize, flo
     {
         return -99.;
     }
-    fTGrad = iTGrad * iTGrad;
+    fNtubes = iNtubes;
+    fTGrad = iTGrad;
     fZe = iZe;
     fAz = iAz;
     // %%@^#%!@(#

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -186,6 +186,8 @@ void VTableLookupDataHandler::fill()
             fsize_short[ii]   = fsize[i];
             fntubes_short[ii] = fntubes[i];
             ftgrad_x_short[ii] = ftgrad_x[i];
+            fasym_short[ii]  = fasym[i];
+            fFitstat_short[ii] = fFitstat[i];
             
             ii++;
         }
@@ -1703,6 +1705,8 @@ bool VTableLookupDataHandler::setOutputFile( string iOutput, string iOption, str
     fOTree->Branch( "width", fwidth_short, "width[NImages]/F" );
     fOTree->Branch( "length", flength_short, "length[NImages]/F" );
     fOTree->Branch( "tgrad_x", ftgrad_x_short, "tgrad_x[NImages]/F" );
+    fOTree->Branch( "asym", fasym_short, "asym[NImages]/F" );
+    fOTree->Branch( "Fitstat", fFitstat_short, "Fitstat[NImages]/I" );
     
     // image parameters (for all telescopes)
     if( !fShortTree )
@@ -1743,8 +1747,6 @@ bool VTableLookupDataHandler::setOutputFile( string iOutput, string iOption, str
         fOTree->Branch( "sinphi", fsinphi, iTT );
         sprintf( iTT, "tchisq_x[%d]/D", fNTel );
         fOTree->Branch( "tchisq_x", ftchisq_x, iTT );
-        sprintf( iTT, "Fitstat[%d]/I", fNTel );
-        fOTree->Branch( "Fitstat", fFitstat, iTT );
     }
     fOTree->Branch( "DispNImages", &fnxyoff, "DispNImages/i" );
     fOTree->Branch( "DispXoff_T", fXoff_T, "DispXoff_T[NImages]/F" );
@@ -2389,6 +2391,8 @@ void VTableLookupDataHandler::reset()
         fwidth_short[i] = -99.;
         flength_short[i] = -99.;
         ftgrad_x_short[i] = -99.;
+        fasym_short[i] = -99.;
+        fFitstat_short[i] = -99;
         fR_MC[i] = -99.;
         fR_short_MC[i] = -99.;
         fES[i] = -99.;
@@ -2739,6 +2743,8 @@ void VTableLookupDataHandler::resetAll()
         fwidth_short[i] = -99.;
         flength_short[i] = -99.;
         ftgrad_x_short[i] = -99.;
+        fasym_short[i] = -99.;
+        fFitstat_short[i] = -99;
         fR_telType[i] = 0.;
         fLoss_telType[i] = 0.;
         fDistance_telType[i] = 0.;

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -163,11 +163,12 @@ bool trainTMVA( string iOutputDir, float iTrainTest,
     dataloader->AddVariable( "length", 'F' );
     dataloader->AddVariable( "wol",    'F' );
     dataloader->AddVariable( "size"  , 'F' );
+    dataloader->AddVariable( "ntubes"  , 'F' );
     // hard coded ASTRI telescope type
     // (no time gradient is available)
     if( iTelType != 201511619 )
     {
-        dataloader->AddVariable( "tgrad_x*tgrad_x", 'F' );
+        dataloader->AddVariable( "tgrad_x", 'F' );
     }
     if( !iSingleTelescopeAnalysis )
     {
@@ -183,6 +184,10 @@ bool trainTMVA( string iOutputDir, float iTrainTest,
         dataloader->AddVariable( "Rcore", 'F' );
     }
     // spectators
+    dataloader->AddSpectator( "cen_x", 'F' );
+    dataloader->AddSpectator( "cen_y", 'F' );
+    dataloader->AddSpectator( "cosphi", 'F' );
+    dataloader->AddSpectator( "sinphi", 'F' );
     dataloader->AddSpectator( "MCe0", 'F' );
     dataloader->AddSpectator( "MCxoff", 'F' );
     dataloader->AddSpectator( "MCyoff", 'F' );
@@ -199,11 +204,22 @@ bool trainTMVA( string iOutputDir, float iTrainTest,
     // train for direction reconstruction
     else if( iTargetBDT == "BDTDisp" )
     {
+        dataloader->AddSpectator( "dispError", 'F' );
+        dataloader->AddSpectator( "dispPhi", 'F' );
         dataloader->AddTarget( "disp"  , 'F' );
+    }
+    // rotation angle
+    else if( iTargetBDT == "BDTDispPhi" )
+    {
+        dataloader->AddSpectator( "disp", 'F' );
+        dataloader->AddSpectator( "dispError", 'F' );
+        dataloader->AddTarget( "dispPhi"  , 'F' );
     }
     // train for error on disp reconstruction
     else if( iTargetBDT == "BDTDispError" )
     {
+        dataloader->AddSpectator( "disp", 'F' );
+        dataloader->AddSpectator( "dispPhi", 'F' );
         dataloader->AddTarget( "dispError", 'F', "dispError", 0., 10. );
     }
     // train for core reconstruction
@@ -506,6 +522,7 @@ bool writeTrainingFile( const string iInputFile, ULong64_t iTelType,
     float ze = -1.;
     float az = -1.;
     float EmissionHeight = -1.;
+    int   Fitstat = -1;
     
     fMapOfTrainingTree.clear();
     cout << "total number of telescopes: " << i_ntel;
@@ -551,6 +568,7 @@ bool writeTrainingFile( const string iInputFile, ULong64_t iTelType,
             fMapOfTrainingTree[i_tel.TelType]->Branch( "fui"        , &fui        , "fui/F" );
             fMapOfTrainingTree[i_tel.TelType]->Branch( "tgrad_x"    , &tgrad_x    , "tgrad_x/F" );
             fMapOfTrainingTree[i_tel.TelType]->Branch( "meanPedvar_Image"         , &meanPedvar_Image, "meanPedvar_Image/F" );
+            fMapOfTrainingTree[i_tel.TelType]->Branch( "Fitstat"    , &Fitstat    , "Fitstat/I" );
             fMapOfTrainingTree[i_tel.TelType]->Branch( "MCe0"       , &MCe0       , "MCe0/F" );
             fMapOfTrainingTree[i_tel.TelType]->Branch( "MCxoff"     , &MCxoff     , "MCxoff/F" );
             fMapOfTrainingTree[i_tel.TelType]->Branch( "MCyoff"     , &MCyoff     , "MCyoff/F" );
@@ -774,6 +792,7 @@ bool writeTrainingFile( const string iInputFile, ULong64_t iTelType,
             fui         = i_tpars[i]->fui;
             tgrad_x     = i_tpars[i]->tgrad_x;
             meanPedvar_Image = i_tpars[i]->meanPedvar_Image;
+            Fitstat     = i_tpars[i]->Fitstat;
             ze          = 90. - i_showerpars.TelElevation[i];
             az          = i_showerpars.TelAzimuth[i];
             MCe0        = i_showerpars.MCe0;
@@ -822,7 +841,12 @@ bool writeTrainingFile( const string iInputFile, ULong64_t iTelType,
             }
             else
             {
+                disp *= -1.;
                 dispError = sqrt( ( x2 - MCxoff ) * ( x2 - MCxoff ) + ( y2 + MCyoff ) * ( y2 + MCyoff ) );
+            }
+            if( dispError > 0. )
+            {
+                dispError = log10( dispError );
             }
             
             // training target in ratio to size
@@ -896,7 +920,7 @@ int main( int argc, char* argv[] )
     string       iDataDirectory = "";
     string       iLayoutFile = "";
     string       iQualityCut = "size>1.&&ntubes>4.&&width>0.&&width<2.&&length>0.&&length<10.";
-    iQualityCut = iQualityCut + "&&tgrad_x<100.*100.&&loss<0.20&&cross<20.0&&Rcore<2000.";
+    iQualityCut = iQualityCut + "&&tgrad_x<100.&&tgrad_x>-100.&&loss<0.20&&cross<20.0&&Rcore<2000.";
     if( argc >=  7 )
     {
         iTargetBDT =       argv[6]   ;

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -163,12 +163,11 @@ bool trainTMVA( string iOutputDir, float iTrainTest,
     dataloader->AddVariable( "length", 'F' );
     dataloader->AddVariable( "wol",    'F' );
     dataloader->AddVariable( "size"  , 'F' );
-    dataloader->AddVariable( "ntubes"  , 'F' );
     // hard coded ASTRI telescope type
     // (no time gradient is available)
     if( iTelType != 201511619 )
     {
-        dataloader->AddVariable( "tgrad_x", 'F' );
+        dataloader->AddVariable( "tgrad_x*tgrad_x", 'F' );
     }
     if( !iSingleTelescopeAnalysis )
     {
@@ -841,12 +840,7 @@ bool writeTrainingFile( const string iInputFile, ULong64_t iTelType,
             }
             else
             {
-                // disp *= -1.;
                 dispError = sqrt( ( x2 - MCxoff ) * ( x2 - MCxoff ) + ( y2 + MCyoff ) * ( y2 + MCyoff ) );
-            }
-            if( dispError > 0. )
-            {
-                dispError = log10( dispError );
             }
             
             // training target in ratio to size
@@ -920,7 +914,7 @@ int main( int argc, char* argv[] )
     string       iDataDirectory = "";
     string       iLayoutFile = "";
     string       iQualityCut = "size>1.&&ntubes>4.&&width>0.&&width<2.&&length>0.&&length<10.";
-    iQualityCut = iQualityCut + "&&tgrad_x<100.&&tgrad_x>-100.&&loss<0.20&&cross<20.0&&Rcore<2000.";
+    iQualityCut = iQualityCut + "&&tgrad_x<100.*100.&&loss<0.20&&cross<20.0&&Rcore<2000.";
     if( argc >=  7 )
     {
         iTargetBDT =       argv[6]   ;

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -841,7 +841,7 @@ bool writeTrainingFile( const string iInputFile, ULong64_t iTelType,
             }
             else
             {
-                disp *= -1.;
+                // disp *= -1.;
                 dispError = sqrt( ( x2 - MCxoff ) * ( x2 - MCxoff ) + ( y2 + MCyoff ) * ( y2 + MCyoff ) );
             }
             if( dispError > 0. )


### PR DESCRIPTION
1. add ntubes to training

- add ntubes to dispBDT variables

2. train for dispPhi

- add dispPhi as training target (not used)

3. change dispBDTError to log scale

- dispBDTError variable is trained as dispError = log10( dispError );

4. add asym and FitStat to mscw output tree

5. add asym and Fitstat to dispBDT spectator tree