### PR TITLE
Prod5 v10 dl2 writer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -791,23 +791,13 @@ makeEffectiveArea:	$(EFFOBJECT) ./obj/makeEffectiveArea.o
 # DL2 writer fillDL2Trees
 ########################################################
 
-DL2OBJECT =	./obj/VGammaHadronCuts.o ./obj/VGammaHadronCuts_Dict.o \
-		./obj/CData.o \
+DL2OBJECT =	./obj/CData.o \
 		./obj/Ctelconfig.o \
-		./obj/VEvndispRunParameter.o ./obj/VEvndispRunParameter_Dict.o \
-		./obj/VImageCleaningRunParameter.o ./obj/VImageCleaningRunParameter_Dict.o \
-		./obj/VGammaHadronCutsStatistics.o ./obj/VGammaHadronCutsStatistics_Dict.o \
-		./obj/VStarCatalogue.o  ./obj/VStarCatalogue_Dict.o \
-                ./obj/VStar.o ./obj/VStar_Dict.o \
-		./obj/VDB_Connection.o \
 		./obj/VSpectralWeight.o ./obj/VSpectralWeight_Dict.o \
 		./obj/VRunList.o ./obj/VRunList_Dict.o ./obj/CRunSummary.o ./obj/CRunSummary_Dict.o \
-		./obj/VEvndispReconstructionParameter.o ./obj/VEvndispReconstructionParameter_Dict.o \
-		./obj/VTableLookupRunParameter.o ./obj/VTableLookupRunParameter_Dict.o \
 		./obj/VMonteCarloRunHeader.o ./obj/VMonteCarloRunHeader_Dict.o \
 		./obj/VAnalysisUtilities.o ./obj/VAnalysisUtilities_Dict.o \
 		./obj/VEffectiveAreaCalculatorMCHistograms.o ./obj/VEffectiveAreaCalculatorMCHistograms_Dict.o \
-		./obj/VInstrumentResponseFunctionRunParameter.o ./obj/VInstrumentResponseFunctionRunParameter_Dict.o \
 		./obj/VTMVAEvaluator.o ./obj/VTMVAEvaluator_Dict.o \
 		./obj/VTMVARunDataEnergyCut.o ./obj/VTMVARunDataEnergyCut_Dict.o \
 		./obj/VTMVARunDataZenithCut.o ./obj/VTMVARunDataZenithCut_Dict.o \
@@ -817,7 +807,6 @@ DL2OBJECT =	./obj/VGammaHadronCuts.o ./obj/VGammaHadronCuts_Dict.o \
 		./obj/VHistogramUtilities.o ./obj/VHistogramUtilities_Dict.o \
 		./obj/VMathsandFunctions.o ./obj/VMathsandFunctions_Dict.o \
 		./obj/VAstronometry.o ./obj/VAstronometry_Dict.o \
-		./obj/VEnergySpectrumfromLiterature.o ./obj/VEnergySpectrumfromLiterature_Dict.o \
 		./obj/VDL2Writer.o \
 		./obj/fillDL2Trees.o
 

--- a/Makefile
+++ b/Makefile
@@ -968,15 +968,17 @@ PRINTRUNOBJ=	./obj/VEvndispRunParameter.o ./obj/VEvndispRunParameter_Dict.o \
 		./obj/VUtilities.o ./obj/VTableLookupRunParameter.o \
 		./obj/VTableLookupRunParameter_Dict.o ./obj/Ctelconfig.o  \
 		./obj/VMonteCarloRunHeader.o ./obj/VMonteCarloRunHeader_Dict.o \
+		./obj/VTMVARunDataEnergyCut.o ./obj/VTMVARunDataEnergyCut_Dict.o \
+		./obj/VTMVARunDataZenithCut.o ./obj/VTMVARunDataZenithCut_Dict.o \
 		./obj/VEvndispReconstructionParameter.o ./obj/VEvndispReconstructionParameter_Dict.o \
 		./obj/VEffectiveAreaCalculatorMCHistograms.o ./obj/VEffectiveAreaCalculatorMCHistograms_Dict.o \
 		./obj/VSpectralWeight.o ./obj/VSpectralWeight_Dict.o \
 		./obj/VGlobalRunParameter.o ./obj/VGlobalRunParameter_Dict.o \
-        ./obj/VStarCatalogue.o ./obj/VStarCatalogue_Dict.o \
-        ./obj/VStar.o ./obj/VStar_Dict.o \
+		./obj/VStarCatalogue.o ./obj/VStarCatalogue_Dict.o \
+		./obj/VStar.o ./obj/VStar_Dict.o \
 		./obj/VAstronometry.o ./obj/VAstronometry_Dict.o \
-        ./obj/VSkyCoordinatesUtilities.o \
-        ./obj/VDB_Connection.o \
+		./obj/VSkyCoordinatesUtilities.o \
+		./obj/VDB_Connection.o \
 		./obj/printRunParameter.o
 
 ifeq ($(ASTRONMETRY),-DASTROSLALIB)

--- a/Makefile
+++ b/Makefile
@@ -788,6 +788,51 @@ makeEffectiveArea:	$(EFFOBJECT) ./obj/makeEffectiveArea.o
 	@echo "$@ done"
 
 ########################################################
+# DL2 writer fillDL2Trees
+########################################################
+
+DL2OBJECT =	./obj/VGammaHadronCuts.o ./obj/VGammaHadronCuts_Dict.o \
+		./obj/CData.o \
+		./obj/Ctelconfig.o \
+		./obj/VEvndispRunParameter.o ./obj/VEvndispRunParameter_Dict.o \
+		./obj/VImageCleaningRunParameter.o ./obj/VImageCleaningRunParameter_Dict.o \
+		./obj/VGammaHadronCutsStatistics.o ./obj/VGammaHadronCutsStatistics_Dict.o \
+		./obj/VStarCatalogue.o  ./obj/VStarCatalogue_Dict.o \
+                ./obj/VStar.o ./obj/VStar_Dict.o \
+		./obj/VDB_Connection.o \
+		./obj/VSpectralWeight.o ./obj/VSpectralWeight_Dict.o \
+		./obj/VRunList.o ./obj/VRunList_Dict.o ./obj/CRunSummary.o ./obj/CRunSummary_Dict.o \
+		./obj/VEvndispReconstructionParameter.o ./obj/VEvndispReconstructionParameter_Dict.o \
+		./obj/VTableLookupRunParameter.o ./obj/VTableLookupRunParameter_Dict.o \
+		./obj/VMonteCarloRunHeader.o ./obj/VMonteCarloRunHeader_Dict.o \
+		./obj/VAnalysisUtilities.o ./obj/VAnalysisUtilities_Dict.o \
+		./obj/VEffectiveAreaCalculatorMCHistograms.o ./obj/VEffectiveAreaCalculatorMCHistograms_Dict.o \
+		./obj/VInstrumentResponseFunctionRunParameter.o ./obj/VInstrumentResponseFunctionRunParameter_Dict.o \
+		./obj/VTMVAEvaluator.o ./obj/VTMVAEvaluator_Dict.o \
+		./obj/VTMVARunDataEnergyCut.o ./obj/VTMVARunDataEnergyCut_Dict.o \
+		./obj/VTMVARunDataZenithCut.o ./obj/VTMVARunDataZenithCut_Dict.o \
+		./obj/VGlobalRunParameter.o ./obj/VGlobalRunParameter_Dict.o \
+		./obj/VSkyCoordinatesUtilities.o ./obj/VUtilities.o \
+		./obj/VPlotUtilities.o ./obj/VPlotUtilities_Dict.o \
+		./obj/VHistogramUtilities.o ./obj/VHistogramUtilities_Dict.o \
+		./obj/VMathsandFunctions.o ./obj/VMathsandFunctions_Dict.o \
+		./obj/VAstronometry.o ./obj/VAstronometry_Dict.o \
+		./obj/VEnergySpectrumfromLiterature.o ./obj/VEnergySpectrumfromLiterature_Dict.o \
+		./obj/VDL2Writer.o \
+		./obj/fillDL2Trees.o
+
+ifeq ($(ASTRONMETRY),-DASTROSLALIB)
+    DL2OBJECT += ./obj/VASlalib.o
+endif
+
+./obj/fillDL2Trees.o:	./src/fillDL2Trees.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+fillDL2Trees:	$(DL2OBJECT) ./obj/fillDL2Trees.o
+	$(LD) $(LDFLAGS) $^ $(GLIBS) $(OutPutOpt) ./bin/$@
+	@echo "$@ done"
+
+########################################################
 # anasum
 ########################################################
 ANASUMOBJECTS =	./obj/VAnaSum.o ./obj/VGammaHadronCuts.o ./obj/VGammaHadronCuts_Dict.o ./obj/CData.o \

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -202,8 +202,8 @@ class CData
         TBranch*        b_Yoff;                   //!
         TBranch*        b_Xoff_derot;             //!
         TBranch*        b_Yoff_derot;             //!
-		TBranch*        b_Xoff_intersect;             //!
-		TBranch*        b_Yoff_intersect;             //!
+	TBranch*        b_Xoff_intersect;             //!
+	TBranch*        b_Yoff_intersect;             //!
         TBranch*        b_stdS;                   //!
         TBranch*        b_theta2;                 //!
         TBranch*        b_Xcore;                  //!

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -607,7 +607,14 @@ void CData::Init( TTree* tree )
     // MC tree
     if( fMC )
     {
-        fChain->SetBranchAddress( "MCprimary", &MCprimary );
+        if( fChain->GetBranch( "MCprimary" ) )
+        {
+            fChain->SetBranchAddress( "MCprimary", &MCprimary );
+        }
+        else
+        {
+            MCprimary = 0;
+        }
         fChain->SetBranchAddress( "MCe0", &MCe0 );
         fChain->SetBranchAddress( "MCxcore", &MCxcore );
         fChain->SetBranchAddress( "MCycore", &MCycore );
@@ -731,7 +738,14 @@ void CData::Init( TTree* tree )
               Yoff_intersect = 0.;
         }
     
-    fChain->SetBranchAddress( "stdS", &stdS );
+    if( fChain->GetBranchStatus( "stdS" ) )
+    {
+        fChain->SetBranchAddress( "stdS", &stdS );
+    }
+    else
+    {
+        stdS = 0.;
+    }
     if( !fShort )
     {
         fChain->SetBranchAddress( "theta2", &theta2 );
@@ -761,7 +775,14 @@ void CData::Init( TTree* tree )
     }
     
     fChain->SetBranchAddress( "Chi2", &Chi2 );
-    fChain->SetBranchAddress( "meanPedvar_Image", &meanPedvar_Image );
+    if( fChain->GetBranchStatus( "meanPedvar_Image" ) )
+    {
+        fChain->SetBranchAddress( "meanPedvar_Image", &meanPedvar_Image );
+    }
+    else
+    {
+        meanPedvar_Image = 0.;
+    }
     if( !fShort )
     {
         fChain->SetBranchAddress( "meanPedvar_ImageT", meanPedvar_ImageT );

--- a/inc/VDL2Writer.h
+++ b/inc/VDL2Writer.h
@@ -4,14 +4,15 @@
 #define VDL2Writer_H
 
 #include "CData.h"
-#include "VGammaHadronCuts.h"
-#include "VInstrumentResponseFunctionRunParameter.h"
+#include "VTMVAEvaluator.h"
 
 #include "TChain.h"
 #include "TDirectory.h"
 #include "TTree.h"
 
+#include <fstream>
 #include <iomanip>
+#include <sstream>
 #include <string>
 
 using namespace std;
@@ -19,40 +20,37 @@ using namespace std;
 class VDL2Writer
 {
     private:
-        VInstrumentResponseFunctionRunParameter* fRunPara;
-        VGammaHadronCuts* fCuts;
-        bool fIgnoreEnergyReconstruction;
-        bool fIsotropicArrivalDirections;
-        bool fTelescopeTypeCutsSet;
+
+        string fdatafile;
+
+        VTMVAEvaluator *fTMVAEvaluator;
+        string fInstrumentEpoch;
+        string fTMVA_MVAMethod;
+        unsigned int fTMVA_MVAMethodCounter;
+        unsigned int fTMVAWeightFileIndex_Emin;
+        unsigned int fTMVAWeightFileIndex_Emax;
+        unsigned int fTMVAWeightFileIndex_Zmin;
+        unsigned int fTMVAWeightFileIndex_Zmax;
+        double fTMVAEnergyStepSize;
+        string fTMVAWeightFile;
         
         // event data
         TTree *fEventTreeCuts;
-        int fCut_Class;
         float fCut_MVA;
 
-        void               fillEventDataTree( int iCutClass, float iMVA );
+        void fillEventDataTree( float iMVA );
+        bool initializeTMVAEvaluator( CData *d );
+        bool readConfigFile( string iConfigFile );
         
     public:
     
-        VDL2Writer( VInstrumentResponseFunctionRunParameter*, VGammaHadronCuts* );
+        VDL2Writer( string iConfigFile );
        ~VDL2Writer();
-        bool  fill( CData* d, unsigned int iMethod );
-        
+        bool  fill( CData* d );
+        string getDataFile() { return fdatafile; }
         TTree* getEventCutDataTree()
         {
              return fEventTreeCuts;
-        }
-        void setIgnoreEnergyReconstructionCuts( bool iB = false )
-        {
-            fIgnoreEnergyReconstruction = iB;
-        }
-        void setIsotropicArrivalDirections( bool iB = false )
-        {
-            fIsotropicArrivalDirections = iB;
-        }
-        void setTelescopeTypeCuts( bool iB = true )
-        {
-            fTelescopeTypeCutsSet = iB;
         }
 };
 #endif

--- a/inc/VDL2Writer.h
+++ b/inc/VDL2Writer.h
@@ -1,0 +1,58 @@
+//!< VDL2Writer calculate effective areas and energy spectra
+
+#ifndef VDL2Writer_H
+#define VDL2Writer_H
+
+#include "CData.h"
+#include "VGammaHadronCuts.h"
+#include "VInstrumentResponseFunctionRunParameter.h"
+
+#include "TChain.h"
+#include "TDirectory.h"
+#include "TTree.h"
+
+#include <iomanip>
+#include <string>
+
+using namespace std;
+
+class VDL2Writer
+{
+    private:
+        VInstrumentResponseFunctionRunParameter* fRunPara;
+        VGammaHadronCuts* fCuts;
+        bool fIgnoreEnergyReconstruction;
+        bool fIsotropicArrivalDirections;
+        bool fTelescopeTypeCutsSet;
+        
+        // event data
+        TTree *fEventTreeCuts;
+        int fCut_Class;
+        float fCut_MVA;
+
+        void               fillEventDataTree( int iCutClass, float iMVA );
+        
+    public:
+    
+        VDL2Writer( VInstrumentResponseFunctionRunParameter*, VGammaHadronCuts* );
+       ~VDL2Writer();
+        bool  fill( CData* d, unsigned int iMethod );
+        
+        TTree* getEventCutDataTree()
+        {
+             return fEventTreeCuts;
+        }
+        void setIgnoreEnergyReconstructionCuts( bool iB = false )
+        {
+            fIgnoreEnergyReconstruction = iB;
+        }
+        void setIsotropicArrivalDirections( bool iB = false )
+        {
+            fIsotropicArrivalDirections = iB;
+        }
+        void setTelescopeTypeCuts( bool iB = true )
+        {
+            fTelescopeTypeCutsSet = iB;
+        }
+};
+#endif

--- a/inc/VDL2Writer.h
+++ b/inc/VDL2Writer.h
@@ -17,13 +17,49 @@
 
 using namespace std;
 
+#define VDST_MAXTELESCOPES  180
+
+class VTMVA_eval_dist
+{
+   public:
+    VTMVAEvaluator *fTMVAEvaluator;
+    string fInstrumentEpoch;
+    string fTMVA_MVAMethod;
+    unsigned int fTMVA_MVAMethodCounter;
+    unsigned int fTMVAWeightFileIndex_Emin;
+    unsigned int fTMVAWeightFileIndex_Emax;
+    unsigned int fTMVAWeightFileIndex_Zmin;
+    unsigned int fTMVAWeightFileIndex_Zmax;
+    double fTMVAEnergyStepSize;
+    string fTMVAWeightFile;
+
+    bool fIsZombie;
+
+    VTMVA_eval_dist( string i_fTMVA_MVAMethod,
+                     unsigned int i_fTMVA_MVAMethodCounter,
+                     string i_fTMVAWeightFile,
+                     unsigned int i_fTMVAWeightFileIndex_Emin, unsigned int i_fTMVAWeightFileIndex_Emax,
+                     unsigned int i_fTMVAWeightFileIndex_Zmin, unsigned int i_fTMVAWeightFileIndex_Zmax,
+                     double i_fTMVAEnergyStepSize, string i_fInstrumentEpoch,
+                     CData *d );
+   ~VTMVA_eval_dist();
+    double evaluate();
+    
+};
+
 class VDL2Writer
 {
     private:
 
         string fdatafile;
 
-        VTMVAEvaluator *fTMVAEvaluator;
+        // distance (xoff bins)
+        vector< string > dist_mean;
+        vector< float > dist_min;
+        vector< float > dist_max;
+
+        // TMVA
+        vector< VTMVA_eval_dist* > fTMVA;
         string fInstrumentEpoch;
         string fTMVA_MVAMethod;
         unsigned int fTMVA_MVAMethodCounter;
@@ -32,14 +68,53 @@ class VDL2Writer
         unsigned int fTMVAWeightFileIndex_Zmin;
         unsigned int fTMVAWeightFileIndex_Zmax;
         double fTMVAEnergyStepSize;
-        string fTMVAWeightFile;
+        vector< string > fTMVAWeightFile;
         
         // event data
-        TTree *fEventTreeCuts;
+        TTree *fDL2DataTree;
+
+        Int_t runNumber;
+        Int_t eventNumber;
+        Float_t         ArrayPointing_Elevation;
+        Float_t         ArrayPointing_Azimuth;
+        Double_t        MCe0;
+        Double_t        MCxcore;
+        Double_t        MCycore;
+        Double_t        MCaz;
+        Double_t        MCze;
+        Double_t        MCxoff;
+        Double_t        MCyoff;
+        Int_t           NImages;
+        ULong64_t       ImgSel;
+        Double_t        Ze;
+        Double_t        Az;
+        Double_t        Xoff;
+        Double_t        Yoff;
+        Double_t        Xoff_derot;
+        Double_t        Yoff_derot;
+        Float_t         Xoff_intersect;
+        Float_t         Yoff_intersect;
+        Double_t        Xcore;
+        Double_t        Ycore;
+        Double_t        MSCW;
+        Double_t        MSCL;
+        Double_t        Chi2;
+        Double_t        ErecS;
+        Double_t        EChi2S;
+        Double_t        dES;
+        Double_t        ES[VDST_MAXTELESCOPES];
+        Double_t        SizeSecondMax;
+        Float_t         EmissionHeight;
+        Float_t         EmissionHeightChi2;
+        UInt_t          DispNImages;
+        Int_t           NTtype;
+        ULong64_t       TtypeID[VDST_MAXTELESCOPES];
+        UInt_t          NImages_Ttype[VDST_MAXTELESCOPES];
+        Double_t        R[VDST_MAXTELESCOPES];
         float fCut_MVA;
 
         void fillEventDataTree( float iMVA );
-        bool initializeTMVAEvaluator( CData *d );
+        bool initializeTMVAEvaluators( CData *d );
         bool readConfigFile( string iConfigFile );
         
     public:
@@ -48,9 +123,9 @@ class VDL2Writer
        ~VDL2Writer();
         bool  fill( CData* d );
         string getDataFile() { return fdatafile; }
-        TTree* getEventCutDataTree()
+        TTree* getEventDataTree()
         {
-             return fEventTreeCuts;
+             return fDL2DataTree;
         }
 };
 #endif

--- a/inc/VEffectiveAreaCalculator.h
+++ b/inc/VEffectiveAreaCalculator.h
@@ -50,6 +50,7 @@ class VEffectiveAreaCalculator
         
         bool bNOFILE;
         TDirectory* fGDirectory;
+        TFile *fOutputFile;
         
         vector< double > fZe;
         vector< double > fMCZe;
@@ -58,7 +59,7 @@ class VEffectiveAreaCalculator
         vector< vector< vector< vector< double > > > > fEff_SpectralIndex;
         
         // effective areas (reading of effective areas)
-		unsigned int fNBins;                    // bins in the true energy of MC (fEff_E0)
+        unsigned int fNBins;                    // bins in the true energy of MC (fEff_E0)
         unsigned int fBiasBin;                  // bins in the energy bias
         unsigned int fhistoNEbins;              // energy bins for histograms only
         unsigned int fResponseMatricesEbinning; // fine bins for response matrices. Likelihood analysis.
@@ -85,7 +86,7 @@ class VEffectiveAreaCalculator
         
 	// For Binned Likelihood
 	TGraphAsymmErrors* gMeanEffectiveAreaMC;
-	TH2D*			   hMeanResponseMatrix;
+	TH2D*		   hMeanResponseMatrix;
         // unique event counting
         map< unsigned int, unsigned short int> fUniqueEventCounter;
         
@@ -213,10 +214,25 @@ class VEffectiveAreaCalculator
         void Calculate_Bck_solid_angle_norm();
         
         /////////////////////////////
-        // event data
-        TTree *fEventTreeCuts;
-        int fCut_Class;
-        float fCut_MVA;
+        // DL2 event data tree
+        TTree *fDL2EventTree;
+        UInt_t fDL2_runNumber;
+        UInt_t fDL2_eventNumber;
+        float fDL2_MCaz;
+        float fDL2_MCel;
+        float fDL2_MCe0;
+        float fDL2_MCxoff;
+        float fDL2_MCyoff;
+        float fDL2_ArrayPointing_Elevation;
+        float fDL2_ArrayPointing_Azimuth;
+        float fDL2_az;
+        float fDL2_el;
+        float fDL2_xoff;
+        float fDL2_yoff;
+        float fDL2_erec;
+        UChar_t fDL2_nimages;
+        UChar_t fDL2_Cut_Class;
+        float fDL2_Cut_MVA;
 
         // effective area smoothing
         int fSmoothIter;
@@ -241,7 +257,7 @@ class VEffectiveAreaCalculator
         void               copyProfileHistograms( TProfile*,  TProfile* );
         void               copyHistograms( TH1*,  TH1*, bool );
         void               fillAngularResolution( unsigned int i_az, bool iContaintment_80p );
-        void               fillEventDataTree( int iCutClass, float iMVA );
+        void               fillDL2EventDataTree( CData *c, UChar_t iCutClass, float iMVA );
         void               fillEcutSub( double iE, enum E_HIS1D iCutIndex );
         void               fillHistogram( int iHisType, int iHisN, 
                                           unsigned int s, unsigned i_az, 
@@ -280,7 +296,8 @@ class VEffectiveAreaCalculator
 				  int iEffectiveAreaVsEnergyMC = 2, bool iLikelihoodAnalysis = false, bool iIsOn = false );
         // constructor for filling
         VEffectiveAreaCalculator( VInstrumentResponseFunctionRunParameter*, 
-                                  vector< VGammaHadronCuts* > );
+                                  vector< VGammaHadronCuts* >,
+                                  TFile* );
         ~VEffectiveAreaCalculator();
         
         void               cleanup();
@@ -294,9 +311,9 @@ class VEffectiveAreaCalculator
         {
                 return fhistoNEbins;
         }
-        TTree*             getEventCutDataTree()
+        TTree*             getEventDL2DataTree()
         {
-                return fEventTreeCuts;
+                return fDL2EventTree;
         }
         TTree*             getAcceptance_AfterCuts()
         {

--- a/inc/VEffectiveAreaCalculator.h
+++ b/inc/VEffectiveAreaCalculator.h
@@ -105,7 +105,7 @@ class VEffectiveAreaCalculator
         VInstrumentResponseFunctionRunParameter* fRunPara;
         
         // gamma hadron cuts
-        VGammaHadronCuts* fCuts;
+        vector< VGammaHadronCuts* > fCuts;
         bool fIgnoreEnergyReconstruction;
         bool fIsotropicArrivalDirections;
         bool fTelescopeTypeCutsSet;
@@ -251,6 +251,7 @@ class VEffectiveAreaCalculator
         double             getEffectiveAreasFromHistograms( double erec, double ze, double woff, double iPedVar,
                 double iSpectralIndex, bool bAddtoMeanEffectiveArea = true );
         string             getEffectiveAreaNamefromEnumInt( int i, string iType );
+        VGammaHadronCuts*  getGammaHadronCuts( CData* c );
         bool               getMonteCarloSpectra( VEffectiveAreaCalculatorMCHistograms* );
         double             getMCSolidAngleNormalization();
         vector< unsigned int > getUpperLowBins( vector< double > i_values, double d );
@@ -273,10 +274,13 @@ class VEffectiveAreaCalculator
         
     public:
     
+        // constructor for reading
         VEffectiveAreaCalculator( string ieffFile, double azmin, double azmax, double iPedVar, double iIndex,
                                   vector< double> fMCZe, int iSmoothIter = -1, double iSmoothThreshold = 1.,
-				  int iEffectiveAreaVsEnergyMC = 2, bool iLikelihoodAnalysis = false, bool iIsOn = false );          // constructor for reading
-        VEffectiveAreaCalculator( VInstrumentResponseFunctionRunParameter*, VGammaHadronCuts* );       // constructor for filling
+				  int iEffectiveAreaVsEnergyMC = 2, bool iLikelihoodAnalysis = false, bool iIsOn = false );
+        // constructor for filling
+        VEffectiveAreaCalculator( VInstrumentResponseFunctionRunParameter*, 
+                                  vector< VGammaHadronCuts* > );
         ~VEffectiveAreaCalculator();
         
         void               cleanup();

--- a/inc/VGammaHadronCuts.h
+++ b/inc/VGammaHadronCuts.h
@@ -431,7 +431,7 @@ class VGammaHadronCuts : public VAnalysisUtilities
             return ( fGammaHadronCutSelector / 10 == 4 );
         }
         bool useThisCut( CData *c );
-        void setCutCharacteristicsMCAZ( float iZ, float iT = 5. )
+        void setCutCharacteristicsMCAZ( float iZ, float iT = 60. )
         {
             fCutCharacteristicsMCAZ = iZ;
             fCutCharacteristicsMCAZ_tolerance = iT;

--- a/inc/VGammaHadronCuts.h
+++ b/inc/VGammaHadronCuts.h
@@ -417,7 +417,7 @@ class VGammaHadronCuts : public VAnalysisUtilities
         {
             fCut_Theta2_max = it2;
         }
-        void   terminate( bool iShort = false );
+        void   terminate( bool iShort = false, string iObjectName = "GammaHadronCuts" );
         bool   useDeepLearnerCuts()
         {
             return ( fReconstructionType == DEEPLEARNER );
@@ -426,10 +426,11 @@ class VGammaHadronCuts : public VAnalysisUtilities
         {
             return ( fGammaHadronCutSelector / 10 == 4 );
         }
+        bool useThisCut( CData *c );
         void setReconstructionType( E_ReconstructionType type )
         {
             fReconstructionType = type;
         }
-        ClassDef( VGammaHadronCuts, 67 );
+        ClassDef( VGammaHadronCuts, 68 );
 };
 #endif

--- a/inc/VGammaHadronCuts.h
+++ b/inc/VGammaHadronCuts.h
@@ -166,6 +166,10 @@ class VGammaHadronCuts : public VAnalysisUtilities
         
         // cut statistics
         VGammaHadronCutsStatistics* fStats;                       //!
+
+        // selection criteria for use this cut
+        float fCutCharacteristicsMCAZ;
+        float fCutCharacteristicsMCAZ_tolerance;
         
         bool   applyProbabilityCut( int i, bool fIsOn );
         bool   applyDeepLearnerCut();
@@ -427,10 +431,15 @@ class VGammaHadronCuts : public VAnalysisUtilities
             return ( fGammaHadronCutSelector / 10 == 4 );
         }
         bool useThisCut( CData *c );
+        void setCutCharacteristicsMCAZ( float iZ, float iT = 5. )
+        {
+            fCutCharacteristicsMCAZ = iZ;
+            fCutCharacteristicsMCAZ_tolerance = iT;
+        }
         void setReconstructionType( E_ReconstructionType type )
         {
             fReconstructionType = type;
         }
-        ClassDef( VGammaHadronCuts, 68 );
+        ClassDef( VGammaHadronCuts, 69 );
 };
 #endif

--- a/inc/VGammaHadronCuts.h
+++ b/inc/VGammaHadronCuts.h
@@ -84,6 +84,7 @@ class VGammaHadronCuts : public VAnalysisUtilities
     private:
     
         bool   fDebug;                               // lots of debug output
+        string fCutID;
         
         CData* fData;                                       //! transient
         string fDataDirectory;
@@ -243,7 +244,7 @@ class VGammaHadronCuts : public VAnalysisUtilities
         
         vector< VNTelTypeCut* > fNTelTypeCut;
         
-        VGammaHadronCuts();
+        VGammaHadronCuts( string iCutID = "0" );
         ~VGammaHadronCuts();
         
         bool   applyDirectionCuts( bool bCount = false, double x0 = -99999., double y0 = -99999. );
@@ -440,6 +441,6 @@ class VGammaHadronCuts : public VAnalysisUtilities
         {
             fReconstructionType = type;
         }
-        ClassDef( VGammaHadronCuts, 69 );
+        ClassDef( VGammaHadronCuts, 70 );
 };
 #endif

--- a/inc/VGammaHadronCutsStatistics.h
+++ b/inc/VGammaHadronCutsStatistics.h
@@ -41,14 +41,14 @@ class VGammaHadronCutsStatistics : public TNamed
         {
             return fData;
         }
-        void         initialize();
+        void         initialize( string iName );
         void         printCutStatistics();
         void         reset();
         void         setCutCounter( unsigned int iCut, unsigned int iValue );
         void         terminate();
         void         updateCutCounter( unsigned int iCut );
         
-        ClassDef( VGammaHadronCutsStatistics, 2 );
+        ClassDef( VGammaHadronCutsStatistics, 3 );
 };
 
 

--- a/inc/VInstrumentResponseFunction.h
+++ b/inc/VInstrumentResponseFunction.h
@@ -51,7 +51,7 @@ class VInstrumentResponseFunction
         vector< vector< VInstrumentResponseFunctionData* > > fIRFData;
         
         // cuts
-        VGammaHadronCuts* fAnaCuts;
+        vector< VGammaHadronCuts* > fAnaCuts;
         bool              fTelescopeTypeCutsSet;
         
         // effective area calculation
@@ -67,6 +67,7 @@ class VInstrumentResponseFunction
         
         bool    defineHistograms();
         bool    fillEventData();
+        VGammaHadronCuts* getGammaHadronCuts( CData* );
         
     public:
     
@@ -112,20 +113,14 @@ class VInstrumentResponseFunction
         }
         bool   initialize( string iName, string iType, unsigned int iNTel, double iMCMaxCoreRadius,
                            double iZe, int iNoise, double iPedvars, double iXoff, double iYoff );
-        void   printCutStatistics()
-        {
-               if( fAnaCuts ) 
-               {
-                   fAnaCuts->printCutStatistics();
-               }
-        }
+        void   printCutStatistics();
         void   setDuplicationID( unsigned int iDuplicationID = 9999 );
         void   setEnergyReconstructionMethod( unsigned int iMethod );
-        void   setCuts( VGammaHadronCuts* iCuts );
+        void   setCuts( vector< VGammaHadronCuts* > iCuts );
 	void   setContainmentProbability( double iP = 0.68, double iPError = 0.95 )
         {
             fContainmentProbability = iP;
-			fContainmentProbabilityError = iPError;
+     	    fContainmentProbabilityError = iPError;
         }
         void   setDataTree( CData* iData );
         void   setMonteCarloEnergyRange( double iMin, double iMax, double iMCIndex = 2. );

--- a/inc/VInstrumentResponseFunctionRunParameter.h
+++ b/inc/VInstrumentResponseFunctionRunParameter.h
@@ -37,6 +37,7 @@ class VInstrumentResponseFunctionRunParameter : public TNamed
         bool            fEffArea_short_writing;    // short/long tree writing
         
         vector< string > fCutFileName;
+        vector< float >  fCutCharacteristicMCAZ;
         string          fInstrumentEpoch;
         vector< unsigned int > fTelToAnalyse;             // telescopes used in analysis (optional, not always filled)
         int             fGammaHadronCutSelector;
@@ -110,13 +111,14 @@ class VInstrumentResponseFunctionRunParameter : public TNamed
         ~VInstrumentResponseFunctionRunParameter() {}
         
         vector< string >      getCutFileName() { return fCutFileName; }
+        vector< float >       getCutCharacteristicMCAZ() { return fCutCharacteristicMCAZ; }
         string                getInstrumentEpoch( bool iMajor = false );	
         void                  print();
         VMonteCarloRunHeader* readMCRunHeader();
         bool                  readRunParameterFromTextFile( string iFile );
         bool                  testRunparameters();
         
-        ClassDef( VInstrumentResponseFunctionRunParameter, 19 );
+        ClassDef( VInstrumentResponseFunctionRunParameter, 20 );
 };
 
 #endif

--- a/inc/VInstrumentResponseFunctionRunParameter.h
+++ b/inc/VInstrumentResponseFunctionRunParameter.h
@@ -113,12 +113,13 @@ class VInstrumentResponseFunctionRunParameter : public TNamed
         vector< string >      getCutFileName() { return fCutFileName; }
         vector< float >       getCutCharacteristicMCAZ() { return fCutCharacteristicMCAZ; }
         string                getInstrumentEpoch( bool iMajor = false );	
+        TTree*                getTelConfigTree();
         void                  print();
         VMonteCarloRunHeader* readMCRunHeader();
         bool                  readRunParameterFromTextFile( string iFile );
         bool                  testRunparameters();
         
-        ClassDef( VInstrumentResponseFunctionRunParameter, 20 );
+        ClassDef( VInstrumentResponseFunctionRunParameter, 21 );
 };
 
 #endif

--- a/inc/VInstrumentResponseFunctionRunParameter.h
+++ b/inc/VInstrumentResponseFunctionRunParameter.h
@@ -36,7 +36,7 @@ class VInstrumentResponseFunctionRunParameter : public TNamed
         unsigned int    fFillingMode;              // filling mode
         bool            fEffArea_short_writing;    // short/long tree writing
         
-        string          fCutFileName;
+        vector< string > fCutFileName;
         string          fInstrumentEpoch;
         vector< unsigned int > fTelToAnalyse;             // telescopes used in analysis (optional, not always filled)
         int             fGammaHadronCutSelector;
@@ -109,13 +109,14 @@ class VInstrumentResponseFunctionRunParameter : public TNamed
         VInstrumentResponseFunctionRunParameter();
         ~VInstrumentResponseFunctionRunParameter() {}
         
+        vector< string >      getCutFileName() { return fCutFileName; }
         string                getInstrumentEpoch( bool iMajor = false );	
         void                  print();
         VMonteCarloRunHeader* readMCRunHeader();
         bool                  readRunParameterFromTextFile( string iFile );
         bool                  testRunparameters();
         
-        ClassDef( VInstrumentResponseFunctionRunParameter, 18 );
+        ClassDef( VInstrumentResponseFunctionRunParameter, 19 );
 };
 
 #endif

--- a/inc/VTMVAEvaluator.h
+++ b/inc/VTMVAEvaluator.h
@@ -185,7 +185,7 @@ class VTMVAEvaluator : public TNamed, public VPlotUtilities
                 double& i_TMVACutValue_AtMaximum );
         TGraph*          getInterpolatedDifferentialRatesfromGraph2D( TObject* i_G, double i_ze_min, double i_ze_max );
         double           getAverageDifferentialRateFromGraph2D( TObject* i_G, double i_e_min, double i_e_max, double i_ze_min, double i_ze_max );
-        void             fillTMVAEvaluatorResults();
+        void             fillTMVAEvaluatorResults( string iCutID = "" );
         unsigned int     getDataBin( double iErec_log10TeV, double iZe );
         unsigned int     getDataBin( double iErec_log10TeV, unsigned int iZeBin );
         vector< double > getDataBinWeights( double iErec_log10TeV, unsigned int iZeBin );
@@ -262,7 +262,8 @@ class VTMVAEvaluator : public TNamed, public VPlotUtilities
                                       unsigned int iWeightFileIndex_Emin, unsigned int iWeightFileIndex_Emax,
                                       unsigned int iWeightFileIndex_Zmin, unsigned int iWeightFileIndex_Zmax,
                                       double iEnergyStepSize = 0.2, string iInstrumentEpoch = "noepoch",
-                                      string iOptimizationType = "UseInterpolatedCounts" );
+                                      string iOptimizationType = "UseInterpolatedCounts",
+                                      string iCutID = "" );
         bool   initializeDataStrutures( CData* iC );
         bool   IsZombie()
         {
@@ -351,7 +352,7 @@ class VTMVAEvaluator : public TNamed, public VPlotUtilities
         void   setTMVAMethod( string iMethodName = "BDT", int iMethodCounter = 0 );
         bool   writeOptimizedMVACutValues( string iRootFile );
         
-        ClassDef( VTMVAEvaluator, 50 );
+        ClassDef( VTMVAEvaluator, 51 );
 };
 
 #endif

--- a/inc/VTMVARunData.h
+++ b/inc/VTMVARunData.h
@@ -78,6 +78,7 @@ class VTMVARunData : public TNamed
         TCut              fQualityCuts;
         TCut              fQualityCutsBkg;
         TCut              fQualityCutsSignal;
+        TCut              fMultiplicityCuts;
         TCut              fMCxyoffCut;
         bool              fMCxyoffCutSignalOnly;
         TCut              fAzimuthCut;

--- a/inc/VTMVARunData.h
+++ b/inc/VTMVARunData.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "VTableLookupRunParameter.h"
 #include "VTMVARunDataEnergyCut.h"
 #include "VTMVARunDataZenithCut.h"
 #include "VUtilities.h"
@@ -59,6 +60,7 @@ class VTMVARunData : public TNamed
         double            fBackgroundWeight;
         vector< string >  fBackgroundFileName;
         vector< TChain* > fBackgroundTree;
+        string            fSelectedEventTreeName;
         
         // list of training variables
         vector< string >  fTrainingVariable;
@@ -97,6 +99,7 @@ class VTMVARunData : public TNamed
         VTMVARunData();
         ~VTMVARunData() {}
         void print();
+        VTableLookupRunParameter* getTLRunParameter();
         bool readConfigurationFile( char* );
         bool openDataFiles( bool iCheckMinEvents = true );
         void setDebug( bool iB = true )
@@ -109,7 +112,7 @@ class VTMVARunData : public TNamed
         }
         void shuffleFileVectors();
         
-        ClassDef( VTMVARunData, 13 );
+        ClassDef( VTMVARunData, 14 );
 };
 
 #endif

--- a/inc/VWPPhysSensitivityFile.h
+++ b/inc/VWPPhysSensitivityFile.h
@@ -9,6 +9,7 @@
 #include "TH3F.h"
 #include "TList.h"
 #include "TPaveText.h"
+#include "TTree.h"
 
 #include <iostream>
 #include <map>
@@ -36,6 +37,7 @@ class VWPPhysSensitivityFile
         
         TFile*       fOutFile;
         string       fDataFile_gamma_onSource;
+        string       fDataFile_gamma_onSource_fullDir;
         string       fDataFile_gamma_cone;
         string       fDataFile_proton;
         string       fDataFile_proton_onSource;
@@ -81,6 +83,7 @@ class VWPPhysSensitivityFile
         TH1F* fTheta2;
         TH1F* fTheta;
         
+        TTree* getTelConfigTree( string );
         void writeHistogramDescription();
         
     public:

--- a/src/VDL2Writer.cpp
+++ b/src/VDL2Writer.cpp
@@ -1,0 +1,271 @@
+/*! \class VDLWriter
+ *  \brief writes DL2 cut event lists
+ *
+ */
+
+#include "VDL2Writer.h"
+
+/*!
+ *
+ */
+VDL2Writer::VDL2Writer( VInstrumentResponseFunctionRunParameter* iRunPara, 
+                        VGammaHadronCuts* icuts )
+{
+    fRunPara = iRunPara;
+    if( !fRunPara )
+    {
+        cout << "VDL2Writer: no run parameters given" << endl;
+        cout << "...exiting..." << endl;
+        exit( EXIT_FAILURE );
+    }
+    // cuts
+    fCuts = icuts;
+    setIgnoreEnergyReconstructionCuts( fRunPara->fIgnoreEnergyReconstructionQuality );
+    setIsotropicArrivalDirections( fRunPara->fIsotropicArrivalDirections );
+    setTelescopeTypeCuts( fRunPara->fTelescopeTypeCuts );
+    
+    ////////////////////////////////////
+    // tree with cut results for each event
+    fCut_Class = 0;
+    fCut_MVA = 0.;
+    fEventTreeCuts = new TTree( "fEventTreeCuts", "event cuts" );
+    fEventTreeCuts->Branch( "CutClass", &fCut_Class, "Class/I" );
+    fEventTreeCuts->Branch( "MVA", &fCut_MVA, "MVA/F" );
+}
+
+/////////////////////////////////////////////////////////////////////////////////////
+
+VDL2Writer::~VDL2Writer()
+{
+}
+
+/*
+ *
+ *  event loop 
+ *
+ */
+bool VDL2Writer::fill( CData* d, 
+                       unsigned int iMethod )
+{
+    // lots of debug output
+    bool bDebugCuts = false;
+    
+    // do not require successfull energy reconstruction
+    if( fIgnoreEnergyReconstruction )
+    {
+        iMethod = 100;
+    }
+    
+    // reset unique event counter
+    //	fUniqueEventCounter.clear();
+    int iSuccessfullEventStatistics = 0;
+    
+    //////////////////////////////////////////////////////////////////
+    // print some run information
+    cout << endl;
+    cout << "DL2 Eventlist filling" << endl;
+    if( fRunPara && fRunPara->fIgnoreFractionOfEvents > 0. )
+    {
+        cout << "\t ignore first " << fRunPara->fIgnoreFractionOfEvents * 100. << " % of events" << endl;
+    }
+    cout << endl;
+    
+    // make sure that all data pointers exist
+    if( !d )
+    {
+        cout << "VDL2Writer::fill error: no data tree" << endl;
+        return false;
+    }
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // reset cut statistics
+    fCuts->resetCutStatistics();
+    
+    ///////////////////////////////////////////////////////
+    // get full data set and loop over all entries
+    ///////////////////////////////////////////////////////
+    Long64_t d_nentries = d->fChain->GetEntries();
+    Long64_t i_start = 0;
+    if( fRunPara && fRunPara->fIgnoreFractionOfEvents > 0. )
+    {
+        i_start = ( Long64_t )( fRunPara->fIgnoreFractionOfEvents * d_nentries );
+    }
+    cout << "\t total number of data events: " << d_nentries;
+    cout << " (start at event " << i_start << ")" << endl;
+    
+    // loop over all events
+    for( Long64_t i = i_start; i < d_nentries; i++ )
+    {
+        d->GetEntry( i );
+
+        // update cut statistics
+        fCuts->newEvent();
+        
+        if( bDebugCuts )
+        {
+            cout << "============================== " << endl;
+            cout << "EVENT entry number " << i << endl;
+        }
+        
+        // apply MC cuts
+        if( bDebugCuts )
+        {
+            cout << "#0 CUT MC " << fCuts->applyMCXYoffCut( d->MCxoff, d->MCyoff, false ) << endl;
+        }
+        
+        if( !fCuts->applyMCXYoffCut( d->MCxoff, d->MCyoff, true ) )
+        {
+            fillEventDataTree( VGammaHadronCutsStatistics::eMC_XYoff, -1. );
+            continue;
+        }
+        
+        ////////////////////////////////
+        // apply general quality and gamma/hadron separation cuts
+        
+        // apply reconstruction cuts
+        if( bDebugCuts )
+        {
+            cout << "#1 CUT applyInsideFiducialAreaCut ";
+            cout << fCuts->applyInsideFiducialAreaCut();
+            cout << "\t" << fCuts->applyStereoQualityCuts( iMethod, false, i, true ) << endl;
+        }
+        
+        // apply fiducial area cuts
+        if( !fCuts->applyInsideFiducialAreaCut( true ) )
+        {
+            fillEventDataTree( 2, -1. );
+            continue;
+        }
+        
+        // apply reconstruction quality cuts
+        if( !fCuts->applyStereoQualityCuts( iMethod, true, i , true ) )
+        {
+            fillEventDataTree( 3, -1. );
+            continue;
+        }
+        
+        // apply telescope type cut (e.g. for CTA simulations)
+        if( fTelescopeTypeCutsSet )
+        {
+            if( bDebugCuts )
+            {
+                cout << "#2 Cut NTELType " << fCuts->applyTelTypeTest( false ) << endl;
+            }
+            if( !fCuts->applyTelTypeTest( true ) )
+            {
+                fillEventDataTree( 4, -1. );
+                continue;
+            }
+        }
+        
+        //////////////////////////////////////
+        // apply direction cut
+        //
+        // bDirectionCut = false: if direction is inside
+        // theta_min and theta_max
+        //
+        // point source cut; use MC shower direction as reference direction
+        bool bDirectionCut = false;
+        if( !fIsotropicArrivalDirections )
+        {
+            if( !fCuts->applyDirectionCuts( true ) )
+            {
+                bDirectionCut = true;
+            }
+        }
+        // background cut; use (0,0) as reference direction
+        // (command line option -d)
+        else
+        {
+            if( !fCuts->applyDirectionCuts( true, 0., 0. ) )
+            {
+                bDirectionCut = true;
+            }
+        }
+        
+        //////////////////////////////////////
+        // apply energy reconstruction quality cut
+        if( !fIgnoreEnergyReconstruction )
+        {
+            if( bDebugCuts )
+            {
+                cout << "#4 EnergyReconstructionQualityCuts";
+                cout << fCuts->applyEnergyReconstructionQualityCuts( iMethod ) << endl;
+            }
+            if( !fCuts->applyEnergyReconstructionQualityCuts( iMethod, true ) )
+            {
+                fillEventDataTree( 6, -1. );
+                continue;
+            }
+        }
+        //////////////////////////////////////
+        // apply gamma hadron cuts
+        if( bDebugCuts )
+        {
+            cout << "#3 CUT ISGAMMA " << fCuts->isGamma( i ) << endl;
+        }
+        if( !fCuts->isGamma( i, true ) )
+        {
+            fillEventDataTree( 7, fCuts->getTMVA_EvaluationResult() );
+            continue;
+        }
+        if( !bDirectionCut )
+        {
+            fillEventDataTree( 5, fCuts->getTMVA_EvaluationResult() );
+        }
+        // remaining events
+        else
+        {
+            fillEventDataTree( 0, fCuts->getTMVA_EvaluationResult() );
+        }
+        
+        // unique event counter
+        // (make sure that map doesn't get too big)
+        if( !bDirectionCut && iSuccessfullEventStatistics >= 0 )
+        {
+            iSuccessfullEventStatistics++;
+        }
+    }  // end of loop
+    /////////////////////////////////////////////////////////////////////////////
+    fCuts->printCutStatistics();
+    if( iSuccessfullEventStatistics < 0 )
+    {
+        iSuccessfullEventStatistics *= -1;
+    }
+    cout << "\t total number of events after cuts: " << iSuccessfullEventStatistics << endl;
+    
+    return true;
+}
+
+
+/* 
+ * fill tree with cut numbers and MVA values per event
+ *
+ * 1    hhEcutTrigger_R (color: 1, marker: 20)
+ * 2    hhEcutFiducialArea_R (color: 2, marker: 20)
+ * 3    hhEcutStereoQuality_R (color: 3, marker: 20)
+ * 4    hhEcutTelType_R (color: 4, marker: 20)
+ * 5    hhEcutDirection_R (color: 5, marker: 20)
+ * 6    hhEcutEnergyReconstruction_R (color: 6, marker: 20)
+ * 7    hhEcutGammaHadron_R (color: 7, marker: 20)
+ *
+ *  1. Events passing gamma/hadron separation cut and direction cut
+ *  fEventTreeCuts->Draw("MVA", "Class==5" );
+ *
+ *  2. Events passing gamma/hadron separation cut and not direction cut
+ *  fEventTreeCuts->Draw("MVA", "Class==0" );
+ *
+ *  3. Events before gamma/hadron separation cut and before direction cut
+ *   fEventTreeCuts->Draw("MVA", "Class==0||Class==7||Class==5", "");
+ *
+ */
+void VDL2Writer::fillEventDataTree( int iCutClass, float iMVA )
+{
+      if( fEventTreeCuts )
+      {
+          fCut_Class = iCutClass;
+          fCut_MVA = iMVA;
+          fEventTreeCuts->Fill();
+      }
+}
+

--- a/src/VEffectiveAreaCalculator.cpp
+++ b/src/VEffectiveAreaCalculator.cpp
@@ -1298,6 +1298,10 @@ void VEffectiveAreaCalculator::reset()
     
 }
 
+/* 
+ * solid angle from MC simulations (cone)
+ *
+ */
 double VEffectiveAreaCalculator::getMCSolidAngleNormalization()
 {
     double iSolAngleNorm = 1.;

--- a/src/VGammaHadronCuts.cpp
+++ b/src/VGammaHadronCuts.cpp
@@ -45,8 +45,9 @@
 
 #include "VGammaHadronCuts.h"
 
-VGammaHadronCuts::VGammaHadronCuts()
+VGammaHadronCuts::VGammaHadronCuts( string iCutID )
 {
+    fCutID = iCutID;
     setDebug( false );
     
     resetCutValues();
@@ -128,7 +129,7 @@ void VGammaHadronCuts::initialize()
 {
     // statistics
     fStats = new VGammaHadronCutsStatistics();
-    fStats->initialize();
+    fStats->initialize( fCutID );
 }
 
 VGammaHadronCuts::~VGammaHadronCuts()
@@ -1911,8 +1912,12 @@ bool VGammaHadronCuts::initTMVAEvaluator( string iTMVAFile,
     fTMVAEvaluator->setTMVAMethod( fTMVA_MVAMethod, fTMVA_MVAMethodCounter );
     fTMVAEvaluator->setTMVAAngularContainmentThetaFixedMinRadius( fTMVAFixedThetaCutMin );
     // read MVA weight files; set MVA cut values (e.g. find optimal values)
-    if( !fTMVAEvaluator->initializeWeightFiles( iTMVAFile, iTMVAWeightFileIndex_Emin, iTMVAWeightFileIndex_Emax,
-            iTMVAWeightFileIndex_Zmin, iTMVAWeightFileIndex_Zmax, iTMVAEnergy_StepSize, fInstrumentEpoch ) )
+    if( !fTMVAEvaluator->initializeWeightFiles( iTMVAFile,
+                                                iTMVAWeightFileIndex_Emin, iTMVAWeightFileIndex_Emax,
+                                                iTMVAWeightFileIndex_Zmin, iTMVAWeightFileIndex_Zmax,
+                                                iTMVAEnergy_StepSize, fInstrumentEpoch,
+                                                "UseInterpolatedCounts",
+                                                fCutID ) )
     {
         cout << "VGammaHadronCuts::initTMVAEvaluator: error while initializing TMVA weight files" << endl;
         cout << "exiting... " << endl;

--- a/src/VGammaHadronCuts.cpp
+++ b/src/VGammaHadronCuts.cpp
@@ -121,7 +121,7 @@ VGammaHadronCuts::VGammaHadronCuts()
     fAngResContainmentProbability = 0;
 
     fCutCharacteristicsMCAZ = -999.;
-    fCutCharacteristicsMCAZ_tolerance = 5.;
+    fCutCharacteristicsMCAZ_tolerance = 60.;
 }
 
 void VGammaHadronCuts::initialize()
@@ -2580,6 +2580,11 @@ bool VGammaHadronCuts::useThisCut( CData *c )
     if( fCutCharacteristicsMCAZ < -998. ) return true;
 
     if( TMath::Abs( c->MCaz - fCutCharacteristicsMCAZ )
+       < fCutCharacteristicsMCAZ_tolerance )
+    {
+        return true;
+    }
+    if( TMath::Abs( c->MCaz - fCutCharacteristicsMCAZ - 360. )
        < fCutCharacteristicsMCAZ_tolerance )
     {
         return true;

--- a/src/VGammaHadronCuts.cpp
+++ b/src/VGammaHadronCuts.cpp
@@ -2166,7 +2166,7 @@ bool VGammaHadronCuts::applyDirectionCuts( bool bCount, double x0, double y0 )
     
     // calculate theta2
     theta2 = ( fData->getXoff() - x0 ) * ( fData->getXoff() - x0 ) + ( fData->getYoff() - y0 ) * ( fData->getYoff() - y0 );
-    
+
     ////////////////////////////////////////////////////////////////////////////////////////////////////
     // fetch theta2 cut (max) (might be energy dependent)
     double i_theta2_cut_max = getTheta2Cut_max( fData->getEnergy_TeV( ) );

--- a/src/VGammaHadronCuts.cpp
+++ b/src/VGammaHadronCuts.cpp
@@ -2566,9 +2566,23 @@ double VGammaHadronCuts::getProbabilityCutAlpha( bool fIsOn )
     
 }
 
-void VGammaHadronCuts::terminate( bool iShort )
+/*
+ * check if this cut should be used
+ * in IRF or effective area calculation
+ */
+bool VGammaHadronCuts::useThisCut( CData *c )
 {
-    SetName( "GammaHadronCuts" );
+    if( !c ) return false;
+
+    // TMPTMPTMPTMP
+
+    return true;
+}
+
+void VGammaHadronCuts::terminate( bool iShort,
+                                  string iObjectName )
+{
+    SetName( iObjectName.c_str() );
     
     if( fStats->getDataTree() && !iShort )
     {

--- a/src/VGammaHadronCuts.cpp
+++ b/src/VGammaHadronCuts.cpp
@@ -119,6 +119,9 @@ VGammaHadronCuts::VGammaHadronCuts()
     fAngRes_AbsoluteMaximum = 1.e10;
     fAngRes_FixedAboveEnergy_TeV = 1.e30;
     fAngResContainmentProbability = 0;
+
+    fCutCharacteristicsMCAZ = -999.;
+    fCutCharacteristicsMCAZ_tolerance = 5.;
 }
 
 void VGammaHadronCuts::initialize()
@@ -2574,9 +2577,15 @@ bool VGammaHadronCuts::useThisCut( CData *c )
 {
     if( !c ) return false;
 
-    // TMPTMPTMPTMP
+    if( fCutCharacteristicsMCAZ < -998. ) return true;
 
-    return true;
+    if( TMath::Abs( c->MCaz - fCutCharacteristicsMCAZ )
+       < fCutCharacteristicsMCAZ_tolerance )
+    {
+        return true;
+    }
+
+    return false;
 }
 
 void VGammaHadronCuts::terminate( bool iShort,

--- a/src/VGammaHadronCutsStatistics.cpp
+++ b/src/VGammaHadronCutsStatistics.cpp
@@ -19,7 +19,7 @@ VGammaHadronCutsStatistics::VGammaHadronCutsStatistics()
     reset();
 }
 
-void VGammaHadronCutsStatistics::initialize()
+void VGammaHadronCutsStatistics::initialize( string iname )
 {
     fCutName.push_back( "Tot               " );
     fCutName.push_back( "MC_XYoff          " );
@@ -37,8 +37,10 @@ void VGammaHadronCutsStatistics::initialize()
     fCutName.push_back( "IsGamma           " );
     fCutName.push_back( "EnergyRec         " );
     fCutName.push_back( "Unkown cut (problem?) " );
+
+    iname = "GammaHadronCutsStats_" + iname;
     
-    fData = new TTree( "GammaHadronCutsStats", "cut statistics for gamma/hadron cuts" );
+    fData = new TTree( iname.c_str(), "cut statistics for gamma/hadron cuts" );
     fData->Branch( "cut", &fCut_bitset_ulong, "cut/l" );
 }
 

--- a/src/VInstrumentResponseFunctionReader.cpp
+++ b/src/VInstrumentResponseFunctionReader.cpp
@@ -636,6 +636,10 @@ bool VInstrumentResponseFunctionReader::getDataFromFile()
     
     // read gamma/hadron cuts from disk
     VGammaHadronCuts* i_cuts = ( VGammaHadronCuts* )iFile->Get( "GammaHadronCuts" );
+    if( !i_cuts )
+    {
+        i_cuts = ( VGammaHadronCuts* )iFile->Get( "GammaHadronCuts_0" );
+    }
     if( i_cuts && gEffArea_Rec )
     {
         // check if theta2 graph was used

--- a/src/VInstrumentResponseFunctionRunParameter.cpp
+++ b/src/VInstrumentResponseFunctionRunParameter.cpp
@@ -303,6 +303,15 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameterFromTextFile( stri
                     is_stream >> temp;
                     fCutFileName.push_back( temp );
                 }
+                if( !(is_stream>>std::ws).eof() )
+                { 
+                   is_stream >> temp;
+                   fCutCharacteristicMCAZ.push_back( atof( temp.c_str() ) );
+                }
+                else 
+                {
+                   fCutCharacteristicMCAZ.push_back( -999. );
+                }
             }
             // * SCATTERMODE <core scatter radius [m]> <type of CORSIKA simulations (FLAT or VIEWCONE)>
             else if( temp == "SCATTERMODE" )
@@ -705,7 +714,12 @@ void VInstrumentResponseFunctionRunParameter::print()
     cout << "cuts: " << endl;
     for( unsigned int i = 0; i < fCutFileName.size(); i++ )
     {
-        cout << "  " << fCutFileName[i] << endl;
+        cout << "  " << fCutFileName[i];
+        if( i < fCutCharacteristicMCAZ.size() )
+        {
+            cout << " (MCAZ " << fCutCharacteristicMCAZ[i] << ")";
+        }
+        cout << endl;
     }
     cout << "cut selectors: ";
     if( fGammaHadronCutSelector >= 0 )

--- a/src/VInstrumentResponseFunctionRunParameter.cpp
+++ b/src/VInstrumentResponseFunctionRunParameter.cpp
@@ -481,6 +481,31 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameterFromTextFile( stri
     return true;
 }
 
+TTree *VInstrumentResponseFunctionRunParameter::getTelConfigTree()
+{
+    TChain c( "data" );
+    TFile* iF = 0;
+    if( c.Add( fdatafile.c_str() ) )
+    {
+        iF = c.GetFile();
+    }
+    if( !iF )
+    {
+        cout << "VInstrumentResponseFunctionRunParameter::getTelConfigTree: error opening data file: ";
+        cout << fdatafile << endl;
+        cout << "exiting..." << endl;
+        exit( EXIT_FAILURE );
+    }
+    TTree *t = (TTree*)iF->Get( "telconfig" );
+    if( t )
+    {
+       return t->CloneTree( -1 );
+    }
+
+    return 0;
+}
+    
+
 
 VMonteCarloRunHeader* VInstrumentResponseFunctionRunParameter::readMCRunHeader()
 {

--- a/src/VInstrumentResponseFunctionRunParameter.cpp
+++ b/src/VInstrumentResponseFunctionRunParameter.cpp
@@ -37,7 +37,6 @@ VInstrumentResponseFunctionRunParameter::VInstrumentResponseFunctionRunParameter
     fhistoNEbins_logTeV_min = fEnergyAxis_logTeV_min;
     fhistoNEbins_logTeV_max = fEnergyAxis_logTeV_max;
     
-    fCutFileName = "";
     fGammaHadronCutSelector = -1;
     fDirectionCutSelector = -1;
     
@@ -301,7 +300,8 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameterFromTextFile( stri
             {
                 if( !(is_stream>>std::ws).eof() )
                 {
-                    is_stream >> fCutFileName;
+                    is_stream >> temp;
+                    fCutFileName.push_back( temp );
                 }
             }
             // * SCATTERMODE <core scatter radius [m]> <type of CORSIKA simulations (FLAT or VIEWCONE)>
@@ -702,8 +702,11 @@ void VInstrumentResponseFunctionRunParameter::print()
     }
     
     cout << endl;
-    cout << "cuts: ";
-    cout << "  " << fCutFileName << endl;
+    cout << "cuts: " << endl;
+    for( unsigned int i = 0; i < fCutFileName.size(); i++ )
+    {
+        cout << "  " << fCutFileName[i] << endl;
+    }
     cout << "cut selectors: ";
     if( fGammaHadronCutSelector >= 0 )
     {

--- a/src/VInstrumentResponseFunctionRunParameter.cpp
+++ b/src/VInstrumentResponseFunctionRunParameter.cpp
@@ -324,7 +324,7 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameterFromTextFile( stri
                 {
                     is_stream >> fFillingMode;
                 }
-                if( fFillingMode > 3 )
+                if( fFillingMode > 3 && fFillingMode < 100 )
                 {
                     cout << "readInputFileList: error: invalid filling mode " << fFillingMode << endl;
                     return false;
@@ -656,25 +656,21 @@ void VInstrumentResponseFunctionRunParameter::print()
     {
         cout << " (calculating complete set of response functions (effective areas, energy, core and angular resolution curves))";
     }
-    if( fFillingMode == 1 )
+    else if( fFillingMode == 1 )
     {
         cout << " (calculating core and angular resolution curves)";
     }
-    if( fFillingMode == 2 )
+    else if( fFillingMode == 2 )
     {
         cout << " (calculating angular resolution curves)";
     }
-    if( fFillingMode == 3 )
+    else if( fFillingMode == 3 )
     {
         cout << " (calculating effective areas and energy resolution curves)";
     }
-    if( fEffArea_short_writing )
+    else if( fFillingMode >= 100 )
     {
-        cout << "( short output )";
-    }
-    else
-    {
-        cout << "( long output )";
+        cout << " (filling DL2 trees )";
     }
     cout << endl;
     if( fFillMCHistograms )

--- a/src/VSensitivityCalculator.cpp
+++ b/src/VSensitivityCalculator.cpp
@@ -2695,13 +2695,28 @@ bool VSensitivityCalculator::getMonteCarlo_EffectiveArea( VSensitivityCalculator
     // calculate solid angle from analysis cuts (or from input parameter theta2)
     // (independent of energy binning of differential sensitivity curves)
     //////////////////////////////////////////////////////////////////////////////////////
-    VGammaHadronCuts* iCuts = ( VGammaHadronCuts* )fEff.Get( "GammaHadronCuts" );
-    if( iCuts )
+    vector< VGammaHadronCuts* > iCuts;
+    if( fEff.Get( "GammaHadronCuts" ) )
+    {
+        iCuts.push_back( (VGammaHadronCuts*)fEff.Get( "GammaHadronCuts" ) );
+    }
+    else if( fEff.Get( "GammaHadronCuts_0" ) && fEff.Get( "GammaHadronCuts_1" ) )
+    {
+        iCuts.push_back( (VGammaHadronCuts*)fEff.Get( "GammaHadronCuts_0" ) );
+        iCuts.push_back( (VGammaHadronCuts*)fEff.Get( "GammaHadronCuts_1" ) );
+    }
+    if( iCuts.size() > 0 )
     {
         // theta2 might be energy dependent
         cout << "calculating solid angle from analysis cuts (might be energy dependent)" << endl;
-        cout << "\t TMVA CUT " << iCuts->getDirectionCutSelector() << endl;
-        iMCPara->theta2_min = iCuts->getTheta2Cut_min();       // theta2 min assumed to be energy independent
+        cout << "\t TMVA CUT " << iCuts[0]->getDirectionCutSelector() << endl;
+        double theta2_min_average = 0.;
+        for( unsigned int c = 0; c < iCuts.size(); c++ )
+        {
+            theta2_min_average +=  iCuts[c]->getTheta2Cut_min();
+        }
+        // theta2 min assumed to be energy independent
+        iMCPara->theta2_min = theta2_min_average / (double)iCuts.size();
         if( iMCPara->theta2_min < 0. )
         {
             iMCPara->theta2_min = 0.;
@@ -2720,7 +2735,12 @@ bool VSensitivityCalculator::getMonteCarlo_EffectiveArea( VSensitivityCalculator
             e = fEnergy_min_Log + i * ( fEnergy_max_Log - fEnergy_min_Log ) / iMCPara->gSolidAngle_DirectionCut_vs_EnergylgTeV->GetN();
             
             // VGammaHadronCuts::getTheta2Cut_max work with lin E
-            itheta2 = iCuts->getTheta2Cut_max( TMath::Power( 10., e ) );
+            double theta2_max_average = 0.;
+            for( unsigned int c = 0; c < iCuts.size(); c++ )
+            {
+                theta2_max_average += iCuts[c]->getTheta2Cut_max( TMath::Power( 10., e ) );
+            }
+            itheta2 = theta2_max_average / (double)iCuts.size();
             if( itheta2 > 0. )
             {
                 iSolidAngle  = 2. * TMath::Pi() * ( 1. - cos( sqrt( itheta2 ) * TMath::Pi() / 180. ) );

--- a/src/VSensitivityCalculator.cpp
+++ b/src/VSensitivityCalculator.cpp
@@ -2760,7 +2760,17 @@ bool VSensitivityCalculator::getMonteCarlo_EffectiveArea( VSensitivityCalculator
     }
     ////////////////////////////////////////////////////////////////////////////////////////////////////
     // read success of TMVA cut optimization from gamma/hadron cuts
+    // (unfortunately a bit of a miss in naming)
     fTMVAEvaluatorResults = ( VTMVAEvaluatorResults* )fEff.Get( "TMVAEvaluatorResults" );
+    if( !fTMVAEvaluatorResults )
+    {
+       fTMVAEvaluatorResults = ( VTMVAEvaluatorResults* )fEff.Get( "TMVAEvaluatorResults_0" );
+    }
+    if( !fTMVAEvaluatorResults )
+    {
+       fTMVAEvaluatorResults = ( VTMVAEvaluatorResults* )fEff.Get( "TMVAEvaluatorResults0" );
+    }
+
     if( fTMVAEvaluatorResults )
     {
         cout << "reading TMVAEvaluatorResults from effective area file (";

--- a/src/VTMVAEvaluator.cpp
+++ b/src/VTMVAEvaluator.cpp
@@ -159,7 +159,8 @@ bool VTMVAEvaluator::initializeWeightFiles( string iWeightFileName,
         unsigned int iWeightFileIndex_Emin, unsigned int iWeightFileIndex_Emax,
         unsigned int iWeightFileIndex_Zmin, unsigned int iWeightFileIndex_Zmax,
         double iEnergyStepSize, string iInstrumentEpoch,
-        string iOptimizationType )
+        string iOptimizationType,
+        string iCutID )
 {
     //////////////////////////////
     // sanity checks
@@ -636,7 +637,7 @@ bool VTMVAEvaluator::initializeWeightFiles( string iWeightFileName,
     // print some info to screen
     cout << "VTMVAEvaluator: Initialized " << fTMVAData.size() << " MVA readers " << endl;
     
-    fillTMVAEvaluatorResults();
+    fillTMVAEvaluatorResults( iCutID );
     
     return true;
 }
@@ -647,12 +648,12 @@ bool VTMVAEvaluator::initializeWeightFiles( string iWeightFileName,
  * VTMVAEvaluatorResults are written to output files and used in
  * anasum, effective areas code and sensitivity calculation
  */
-void VTMVAEvaluator::fillTMVAEvaluatorResults()
+void VTMVAEvaluator::fillTMVAEvaluatorResults( string iCutID )
 {
     if( !fTMVAEvaluatorResults )
     {
         fTMVAEvaluatorResults = new VTMVAEvaluatorResults;
-        fTMVAEvaluatorResults->SetName( "TMVAEvaluatorResults" );
+        fTMVAEvaluatorResults->SetName( ("TMVAEvaluatorResults"+iCutID).c_str() );
     }
     if( fTMVAEvaluatorResults )
     {

--- a/src/VTMVARunData.cpp
+++ b/src/VTMVARunData.cpp
@@ -23,6 +23,7 @@ VTMVARunData::VTMVARunData()
     fQualityCuts = "1";
     fQualityCutsBkg = "1";
     fQualityCutsSignal = "1";
+    fMultiplicityCuts = "1";
     fMCxyoffCut = "1";
     fMCxyoffCutSignalOnly = false;
     fAzimuthCut = "1";
@@ -118,6 +119,7 @@ bool VTMVARunData::openDataFiles( bool iCheckMinEvents )
                         {
                             fSignalTree[k]->Draw( ">>+signalList", 
                                                   fQualityCuts && fQualityCutsSignal 
+                                                  && fMultiplicityCuts
                                                   && fMCxyoffCut && fAzimuthCut && 
                                                   fEnergyCutData[i]->fEnergyCut && 
                                                   fZenithCutData[j]->fZenithCut, 
@@ -131,7 +133,9 @@ bool VTMVARunData::openDataFiles( bool iCheckMinEvents )
                         cout << "number of signal events in energy bin " << i << " zenith bin " << j << ": ";
                         cout << i_j_SignalList->GetN() << "\t required > " << fMinSignalEvents << endl;
                         cout << "  (cuts are " << fQualityCuts << "&&" << fQualityCutsSignal << "&&" << fMCxyoffCut << "&&" << fAzimuthCut;
-                        cout << "&&" << fEnergyCutData[i]->fEnergyCut  << "&&" << fZenithCutData[j]->fZenithCut << ")" << endl;
+                        cout << "&&" << fEnergyCutData[i]->fEnergyCut  << "&&" << fZenithCutData[j]->fZenithCut;
+                        cout << "&&" << fMultiplicityCuts;
+                        cout << ")" << endl;
                         if( i_j_SignalList->GetN() < fMinSignalEvents )
                         {
                             iEnoughEvents = false;
@@ -147,6 +151,7 @@ bool VTMVARunData::openDataFiles( bool iCheckMinEvents )
                         if( fMCxyoffCutSignalOnly )
                         {
                             fBackgroundTree[k]->Draw( ">>+BackgroundList", fQualityCuts && fQualityCutsBkg
+                                                      && fMultiplicityCuts
                                                       && fMCxyoffCut && fAzimuthCut && fEnergyCutData[i]->fEnergyCut
                                                       && fZenithCutData[j]->fZenithCut, "entrylist" );
                             i_j_BackgroundList = ( TEntryList* )gDirectory->Get( "BackgroundList" );
@@ -154,6 +159,7 @@ bool VTMVARunData::openDataFiles( bool iCheckMinEvents )
                         else if( fBackgroundTree[k] )
                         {
                             fBackgroundTree[k]->Draw( ">>+BackgroundList", fQualityCuts && fQualityCutsBkg
+                                                      && fMultiplicityCuts
                                                       && fMCxyoffCut && fAzimuthCut && fEnergyCutData[i]->fEnergyCut
                                                       && fZenithCutData[j]->fZenithCut, "entrylist" );
                             i_j_BackgroundList = ( TEntryList* )gDirectory->Get( "BackgroundList" );
@@ -165,7 +171,9 @@ bool VTMVARunData::openDataFiles( bool iCheckMinEvents )
                         cout << i_j_BackgroundList->GetN();
                         cout << "\t required > " << fMinBackgroundEvents << endl;
                         cout << "  (cuts are " << fQualityCuts << "&&" << fQualityCutsBkg << "&&" << fMCxyoffCut << "&&" << fAzimuthCut;
-                        cout << "&&" << fEnergyCutData[i]->fEnergyCut  << "&&" << fZenithCutData[j]->fZenithCut << ")" << endl;
+                        cout << "&&" << fEnergyCutData[i]->fEnergyCut  << "&&" << fZenithCutData[j]->fZenithCut;
+                        cout << "&&" << fMultiplicityCuts;
+                        cout << ")" << endl;
                         if( i_j_BackgroundList->GetN() < fMinBackgroundEvents )
                         {
                             iEnoughEvents = false;
@@ -308,6 +316,7 @@ void VTMVARunData::print()
     }
     cout << endl;
     cout << "pre-training selection cuts: " << fQualityCuts << endl;
+    cout << "multiplicity cuts: " << fMultiplicityCuts << endl;
     cout << "background specific pre-training selection cuts: " << fQualityCutsBkg << endl;
     cout << "signal specific pre-training selection cuts: " << fQualityCutsSignal << endl;
     cout << "cut on MC arrival directions: " << fMCxyoffCut;
@@ -515,6 +524,19 @@ bool VTMVARunData::readConfigurationFile( char* iC )
                 {
                     cout << "VTMVARunData::readConfigurationFile error while reading input for variable SELECTION_CUTS_SIG" << endl;
                     return false;
+                }
+            }
+            // telescope multiplicity cut
+            if( temp == "TELMULTIPLICITY_CUTS" )
+            {
+                if( !(is_stream>>std::ws).eof() )
+                {
+                   fMultiplicityCuts = is_stream.str().substr( is_stream.tellg(), is_stream.str().size() ).c_str();
+                }
+                else
+                {
+                   cout << "VTMVARunData::readConfigurationFile error while reading input for variable TELMULTIPLICITY_CUTS" << endl;
+                   return false;
                 }
             }
             // MC arrival direction cut

--- a/src/VTableLookupRunParameter.cpp
+++ b/src/VTableLookupRunParameter.cpp
@@ -947,7 +947,7 @@ void VTableLookupRunParameter::print( int iP )
             }
             if( fmaxdistfraction > 0. )
             {
-                cout << "\t BDT  TMVA stereo reconstruction distance cut (fraction of FOV) < ";
+                cout << "\t BDT TMVA stereo reconstruction distance cut (fraction of FOV) < ";
                 cout << fmaxdistfraction << endl;
             }
             if( fmaxloss < 1. )

--- a/src/VWPPhysSensitivityFile.cpp
+++ b/src/VWPPhysSensitivityFile.cpp
@@ -622,6 +622,7 @@ bool VWPPhysSensitivityFile::fillHistograms1D( string iDataDirectory, bool iFill
             std::cout << " fDataFile_gamma_onSource " << fDataFile_gamma_onSource << std::endl;
             iEffectiveAreaFile << iDataDirectory << "/" << fDataFile_gamma_onSource  << ".root";
         }
+        fDataFile_gamma_onSource_fullDir = iEffectiveAreaFile.str();
     }
     cout << endl;
     cout << "=================================================================" << endl;
@@ -1093,10 +1094,38 @@ bool VWPPhysSensitivityFile::terminate()
             }
             cout << endl;
         }
+        fOutFile->cd();
         
+        ////////////////////
+        // copy telconfig tree
+        TTree *t = getTelConfigTree( fDataFile_gamma_onSource_fullDir );
+        fOutFile->cd();
+        if( t )
+        { 
+            t->Write( "telconfig" );
+        } 
         fOutFile->Close();
     }
     return true;
+}
+
+/*
+ * read and clone telconfig tree
+ *
+ */
+TTree* VWPPhysSensitivityFile::getTelConfigTree( string iFile )
+{
+    TFile *iF = new TFile( iFile.c_str() );
+    if( iF->IsZombie() )
+    {
+        return 0;
+    }
+    TTree *t = (TTree*)iF->Get( "telconfig" );
+    if( t && fOutFile->cd() )
+    {
+       return t->CloneTree( -1 );
+    }
+    return 0;
 }
 
 void VWPPhysSensitivityFile::setDataFiles( string iArray, int iRecID )

--- a/src/fillDL2Trees.cpp
+++ b/src/fillDL2Trees.cpp
@@ -1,0 +1,256 @@
+/*! \file  fill DL2 trees
+ *  
+ *  applying gamma / hadron separation (e.g., TMVA)
+ *
+ *   input is a file list of mscw_energy output file from gamma-ray simulations
+ *
+ */
+
+#include "TChain.h"
+#include "TChainElement.h"
+#include "TFile.h"
+#include "TMath.h"
+#include "TObjArray.h"
+#include "TSystem.h"
+#include "TTree.h"
+
+#include "VGlobalRunParameter.h"
+#include "CData.h"
+#include "VEffectiveAreaCalculatorMCHistograms.h"
+#include "VGammaHadronCuts.h"
+#include "VDL2Writer.h"
+#include "VInstrumentResponseFunctionRunParameter.h"
+#include "VMonteCarloRunHeader.h"
+#include "VTableLookupRunParameter.h"
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+VEffectiveAreaCalculatorMCHistograms* copyMCHistograms( TChain* c );
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+int main( int argc, char* argv[] )
+{
+    // print version only
+    if( argc == 2 )
+    {
+        string fCommandLine = argv[1];
+        if( fCommandLine == "-v" || fCommandLine == "--version" )
+        {
+            VGlobalRunParameter iRunPara;
+            cout << iRunPara.getEVNDISP_VERSION() << endl;
+            exit( EXIT_SUCCESS );
+        }
+    }
+    
+    cout << endl;
+    cout << "fillDL2Trees " << VGlobalRunParameter::getEVNDISP_VERSION() << endl;
+    cout << "-----------------------------" << endl;
+    cout << endl;
+    
+    /////////////////////////////////////////////////////////////////
+    // read command line parameters
+    if( argc != 3 )
+    {
+        cout << endl;
+        cout << "./fillDL2Trees" << endl;
+        exit( EXIT_SUCCESS );
+    }
+    string fOutputfileName = argv[2];
+    
+    /////////////////////////////////////////////////////////////////
+    // read run parameters from file
+    VInstrumentResponseFunctionRunParameter* fRunPara = new VInstrumentResponseFunctionRunParameter();
+    fRunPara->SetName( "fillDL2Tree_runparameter" );
+    if( !fRunPara->readRunParameterFromTextFile( argv[1] ) )
+    {
+        cout << "error reading runparameters from text file" << endl;
+        cout << "exiting..." << endl;
+        exit( EXIT_FAILURE );
+    }
+    fRunPara->print();
+    
+    /////////////////////////////////////////////////////////////////
+    // open output file and write results to dist
+    TFile* fOutputfile = new TFile( fOutputfileName.c_str(), "RECREATE" );
+    if( fOutputfile->IsZombie() )
+    {
+        cout << "Error in opening output file: " << fOutputfile->GetName() << endl;
+        cout << "exiting..." << endl;
+        exit( EXIT_FAILURE );
+    }
+    
+    /////////////////////////////////////////////////////////////////
+    // gamma/hadron cuts
+    VGammaHadronCuts* fCuts = new VGammaHadronCuts();
+    fCuts->initialize();
+    fCuts->setNTel( fRunPara->telconfig_ntel, 
+                    fRunPara->telconfig_arraycentre_X, 
+                    fRunPara->telconfig_arraycentre_Y );
+    fCuts->setInstrumentEpoch( fRunPara->getInstrumentEpoch( true ) );
+    fCuts->setTelToAnalyze( fRunPara->fTelToAnalyse );
+    fCuts->setReconstructionType( fRunPara->fReconstructionType );
+    if( !fCuts->readCuts( fRunPara->fCutFileName, 2 ) )
+    {
+        cout << "exiting..." << endl;
+        exit( EXIT_FAILURE ) ;
+    }
+    fRunPara->fGammaHadronCutSelector = fCuts->getGammaHadronCutSelector();
+    fRunPara->fDirectionCutSelector   = fCuts->getDirectionCutSelector();
+    fCuts->initializeCuts( -1, fRunPara->fGammaHadronProbabilityFile );
+    fCuts->printCutSummary();
+    
+    /////////////////////////////////////////////////////////////////
+    // read MC header (might not be there, no problem; but depend on right input in runparameter file)
+    VMonteCarloRunHeader* iMonteCarloHeader = fRunPara->readMCRunHeader();
+    
+    /////////////////////////////////////////////////////////////////////////////
+    // DL2 writer
+    VDL2Writer fDL2Writer( fRunPara, fCuts );
+    
+    /////////////////////////////////////////////////////////////////////////////
+    // set effective area Monte Carlo histogram class
+    VEffectiveAreaCalculatorMCHistograms* fMC_histo = 0;
+    
+    /////////////////////////////////////////////////////////////////////////////
+    // load data chain
+    TChain* c = new TChain( "data" );
+    if( !c->Add( fRunPara->fdatafile.c_str(), -1 ) )
+    {
+        cout << "Error while trying to add mscw data tree from file " << fRunPara->fdatafile  << endl;
+        cout << "exiting..." << endl;
+        exit( EXIT_FAILURE );
+    }
+    
+    CData d( c, true, true );
+    fCuts->setDataTree( &d );
+    d.setReconstructionType( fCuts->fReconstructionType );
+    
+    //////////////////////////////////////////////////////////////////////////////
+    // MC histograms
+    if( fRunPara->fFillingMode != 1 && fRunPara->fFillingMode != 2 )
+    {
+        fMC_histo = copyMCHistograms( c );
+        if( fMC_histo )
+        {
+            fMC_histo->matchDataVectors( fRunPara->fAzMin, 
+                                         fRunPara->fAzMax, 
+                                         fRunPara->fSpectralIndex );
+            fMC_histo->print();
+        }
+        else
+        {
+            cout << "Warning: failed reading MC histograms" << endl;
+        }
+    }
+    
+    //////////////////////////////////////////////////////////////////////////////
+    // fill DL2 trees
+    fOutputfile->cd();
+    fDL2Writer.fill( &d, fRunPara->fEnergyReconstructionMethod );
+    
+    
+    /////////////////////////////////////////////////////////////////////////////
+    /////////////////////////////////////////////////////////////////////////////
+    // write results to disk
+    if( fDL2Writer.getEventCutDataTree() )
+    {
+           cout << "writing event data trees: (";
+           cout << fDL2Writer.getEventCutDataTree()->GetName();
+           cout << ") to " << fOutputfile->GetName() << endl;
+           fOutputfile->cd();
+           if( fDL2Writer.getEventCutDataTree() )
+           {
+               fDL2Writer.getEventCutDataTree()->Write();
+           }
+           if( c )
+           {
+               c->Merge(fOutputfile, 0, "keep" );
+           }
+    }
+        if( fCuts->getMVACutGraphs().size() > 0 )
+        {
+              cout << "writing MVA cut graphs to " << fOutputfile->GetName() << endl;
+              fOutputfile->cd();
+              if( fOutputfile->mkdir( "mvaGraphs" ) )
+              {
+                  fOutputfile->cd( "mvaGraphs" );   
+                  for( unsigned int i = 0; i < fCuts->getMVACutGraphs().size(); i++ )
+                  {
+                      if( fCuts->getMVACutGraphs()[i] )
+                      {
+                          fCuts->getMVACutGraphs()[i]->Write();
+                      }
+                  }
+              }
+              fOutputfile->cd();
+        }
+    // writing cuts to disk
+    if( fCuts )
+    {
+        fCuts->terminate( ( fRunPara->fEffArea_short_writing || fRunPara->fFillingMode == 3 ) );
+    }
+    // writing monte carlo header to disk
+    if( iMonteCarloHeader )
+    {
+        iMonteCarloHeader->Write();
+    }
+    // write run parameters to disk
+    if( fRunPara )
+    {
+        fRunPara->Write();
+    }
+    
+    fOutputfile->Close();
+    cout << "end..." << endl;
+}
+
+/*
+ * return MC histograms from mscw_energy files
+ *
+ * - loop over all mscw_energy files
+ * - add MC histograms
+ */
+VEffectiveAreaCalculatorMCHistograms* copyMCHistograms( TChain* c )
+{
+    VEffectiveAreaCalculatorMCHistograms* iMC_his = 0;
+    if( c )
+    {
+        // loop over all files and add MC histograms
+        TObjArray* fileElements = c->GetListOfFiles();
+        TChainElement* chEl = 0;
+        TIter next( fileElements );
+        unsigned int z = 0;
+        while( ( chEl = ( TChainElement* )next() ) )
+        {
+            TFile* ifInput = new TFile( chEl->GetTitle() );
+            if( !ifInput->IsZombie() )
+            {
+                if( z == 0 )
+                {
+                    iMC_his = ( VEffectiveAreaCalculatorMCHistograms* )ifInput->Get( "MChistos" );
+                }
+                else
+                {
+                    if( iMC_his )
+                    {
+                        iMC_his->add( ( VEffectiveAreaCalculatorMCHistograms* )ifInput->Get( "MChistos" ) );
+                    }
+                    ifInput->Close();
+                }
+                z++;
+            }
+        }
+    }
+    return iMC_his;
+}
+
+

--- a/src/fillDL2Trees.cpp
+++ b/src/fillDL2Trees.cpp
@@ -105,20 +105,20 @@ int main( int argc, char* argv[] )
     fDL2Writer.fill( &d );
     
     // write results to disk
-    if( fDL2Writer.getEventCutDataTree() )
+    if( fDL2Writer.getEventDataTree() )
     {
         cout << "writing event data trees: (";
-        cout << fDL2Writer.getEventCutDataTree()->GetName();
+        cout << fDL2Writer.getEventDataTree()->GetName();
         cout << ") to " << fOutputfile->GetName() << endl;
         fOutputfile->cd();
-        if( fDL2Writer.getEventCutDataTree() )
+        if( fDL2Writer.getEventDataTree() )
         {
-            fDL2Writer.getEventCutDataTree()->Write();
+            fDL2Writer.getEventDataTree()->Write();
         }
-        if( c )
+/*        if( c )
         {
             c->Merge(fOutputfile, 0, "keep" );
-        }
+        } */
     }
     writeMCRunHeader( c, fOutputfile );
     

--- a/src/logFile.cpp
+++ b/src/logFile.cpp
@@ -78,6 +78,12 @@ int main( int argc, char* argv[] )
                 exit( EXIT_FAILURE );
            }
            TMacro *iM = (TMacro*)fF.Get( fLogFileName.c_str() );
+           // xml requires dedicated return if not found
+           if( !iM && fLogFileName.find( "XML" ) != string::npos )
+           {
+               cout << "NOXML" << endl;
+               exit( EXIT_SUCCESS );
+           }
            if( !iM )
            {
                for( unsigned int i = 0; i < logObjectNames.size(); i++ )

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -474,6 +474,12 @@ int main( int argc, char* argv[] )
     {
         iMonteCarloHeader->Write();
     }
+    TTree *i_telconfig = fRunPara->getTelConfigTree();
+    fOutputfile->cd();
+    if( i_telconfig )
+    {
+        i_telconfig->Write( "telconfig" );
+    }
     
     // write run parameters to disk
     if( fRunPara )

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -105,21 +105,29 @@ int main( int argc, char* argv[] )
     
     /////////////////////////////////////////////////////////////////
     // gamma/hadron cuts
-    VGammaHadronCuts* fCuts = new VGammaHadronCuts();
-    fCuts->initialize();
-    fCuts->setNTel( fRunPara->telconfig_ntel, fRunPara->telconfig_arraycentre_X, fRunPara->telconfig_arraycentre_Y );
-    fCuts->setInstrumentEpoch( fRunPara->getInstrumentEpoch( true ) );
-    fCuts->setTelToAnalyze( fRunPara->fTelToAnalyse );
-    fCuts->setReconstructionType( fRunPara->fReconstructionType );
-    if( !fCuts->readCuts( fRunPara->fCutFileName, 2 ) )
+    // (might be a series of cuts)
+
+    vector< VGammaHadronCuts* > fCuts;
+    for( unsigned int i = 0; i < fRunPara->getCutFileName().size(); i++ )
     {
-        cout << "exiting..." << endl;
-        exit( EXIT_FAILURE ) ;
+        fCuts.push_back( new VGammaHadronCuts() );
+        fCuts.back()->initialize();
+        fCuts.back()->setNTel( fRunPara->telconfig_ntel, 
+                               fRunPara->telconfig_arraycentre_X, 
+                               fRunPara->telconfig_arraycentre_Y );
+        fCuts.back()->setInstrumentEpoch( fRunPara->getInstrumentEpoch( true ) );
+        fCuts.back()->setTelToAnalyze( fRunPara->fTelToAnalyse );
+        fCuts.back()->setReconstructionType( fRunPara->fReconstructionType );
+        if( !fCuts.back()->readCuts( fRunPara->fCutFileName[i], 2 ) )
+        {
+            cout << "exiting..." << endl;
+            exit( EXIT_FAILURE ) ;
+        }
+        fRunPara->fGammaHadronCutSelector = fCuts.back()->getGammaHadronCutSelector();
+        fRunPara->fDirectionCutSelector   = fCuts.back()->getDirectionCutSelector();
+        fCuts.back()->initializeCuts( -1, fRunPara->fGammaHadronProbabilityFile );
+        fCuts.back()->printCutSummary();
     }
-    fRunPara->fGammaHadronCutSelector = fCuts->getGammaHadronCutSelector();
-    fRunPara->fDirectionCutSelector   = fCuts->getDirectionCutSelector();
-    fCuts->initializeCuts( -1, fRunPara->fGammaHadronProbabilityFile );
-    fCuts->printCutSummary();
     
     /////////////////////////////////////////////////////////////////
     // read MC header (might not be there, no problem; but depend on right input in runparameter file)
@@ -131,7 +139,7 @@ int main( int argc, char* argv[] )
     
     /////////////////////////////////////////////////////////////////////////////
     // set effective area class
-    VEffectiveAreaCalculator fEffectiveAreaCalculator( fRunPara, fCuts );
+    VEffectiveAreaCalculator fEffectiveAreaCalculator( fRunPara, fCuts[0] );
     
     /////////////////////////////////////////////////////////////////////////////
     // set effective area Monte Carlo histogram class
@@ -206,8 +214,12 @@ int main( int argc, char* argv[] )
     }
     
     CData d( c, true, true );
-    fCuts->setDataTree( &d );
-    d.setReconstructionType( fCuts->fReconstructionType );
+    for( unsigned int i = 0; i < fCuts.size(); i++ )
+    {
+        fCuts[i]->setDataTree( &d );
+    }
+    // expect all cuts using the same reconstruction type
+    d.setReconstructionType( fCuts[0]->fReconstructionType );
     
     /////////////////////////////////////////////////////////////////////////////
     // fill resolution plots
@@ -402,22 +414,31 @@ int main( int argc, char* argv[] )
                    c->Merge(fOutputfile, 0, "keep" );
                }
         }
-        if( fCuts->getMVACutGraphs().size() > 0 )
+        for( unsigned int c = 0; c < fCuts.size(); c++ )
         {
-              cout << "writing MVA cut graphs to " << fOutputfile->GetName() << endl;
-              fOutputfile->cd();
-              if( fOutputfile->mkdir( "mvaGraphs" ) )
-              {
-                  fOutputfile->cd( "mvaGraphs" );   
-                  for( unsigned int i = 0; i < fCuts->getMVACutGraphs().size(); i++ )
+            if( fCuts[c]->getMVACutGraphs().size() > 0 )
+            {
+                  if( c == 0 )
                   {
-                      if( fCuts->getMVACutGraphs()[i] )
-                      {
-                          fCuts->getMVACutGraphs()[i]->Write();
-                      }
+                      cout << "writing MVA cut graphs to ";
+                      cout << fOutputfile->GetName() << endl;
+                      fOutputfile->cd();
                   }
+                  ostringstream mvaDir;
+                  mvaDir << "mvaGraphs_" << c;
+                  if( fOutputfile->mkdir( mvaDir.str().c_str() ) )
+                  {
+                      fOutputfile->cd( mvaDir.str().c_str() );
+                      for( unsigned int i = 0; i < fCuts[c]->getMVACutGraphs().size(); i++ )
+                      {
+                          if( fCuts[c]->getMVACutGraphs()[i] )
+                          {
+                              fCuts[c]->getMVACutGraphs()[i]->Write();
+                          }
+                      }
               }
               fOutputfile->cd();
+           }
         }
     }
     // write resolution data to disk only for long output
@@ -429,9 +450,20 @@ int main( int argc, char* argv[] )
         }
     }
     // writing cuts to disk
-    if( fCuts )
+    ostringstream cutsname;
+    cutsname << "GammaHadronCuts";
+    for( unsigned int i = 0; i < fCuts.size(); i++ )
     {
-        fCuts->terminate( ( fRunPara->fEffArea_short_writing || fRunPara->fFillingMode == 3 ) );
+        if( fCuts.size() > 1 )
+        {
+            cutsname << "_" << i;
+        }
+        if( fCuts[i] )
+        {
+            fCuts[i]->terminate( ( fRunPara->fEffArea_short_writing 
+                                || fRunPara->fFillingMode == 3 ),
+                                 cutsname.str() );
+        }
     }
     // writing monte carlo header to disk
     if( iMonteCarloHeader )

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -143,7 +143,7 @@ int main( int argc, char* argv[] )
     
     /////////////////////////////////////////////////////////////////////////////
     // set effective area class
-    VEffectiveAreaCalculator fEffectiveAreaCalculator( fRunPara, fCuts );
+    VEffectiveAreaCalculator fEffectiveAreaCalculator( fRunPara, fCuts, fOutputfile );
     
     /////////////////////////////////////////////////////////////////////////////
     // set effective area Monte Carlo histogram class
@@ -402,17 +402,19 @@ int main( int argc, char* argv[] )
             fOutputfile->cd();
             fEffectiveAreaCalculator.getAcceptance_AfterCuts()->Write();
         }
-        if( fRunPara->fWriteEventdatatrees 
-        && fEffectiveAreaCalculator.getEventCutDataTree() )
+        if( fEffectiveAreaCalculator.getEventDL2DataTree() )
         {
                cout << "writing event data trees: (";
-               cout << fEffectiveAreaCalculator.getEventCutDataTree()->GetName();
+               cout << fEffectiveAreaCalculator.getEventDL2DataTree()->GetName();
                cout << ") to " << fOutputfile->GetName() << endl;
                fOutputfile->cd();
-               if( fEffectiveAreaCalculator.getEventCutDataTree() )
+               if( fEffectiveAreaCalculator.getEventDL2DataTree() )
                {
-                   fEffectiveAreaCalculator.getEventCutDataTree()->Write();
+                   fEffectiveAreaCalculator.getEventDL2DataTree()->Write();
                }
+       }
+       if( fRunPara->fWriteEventdatatrees )
+       {
                if( c )
                {
                    c->Merge(fOutputfile, 0, "keep" );

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -123,6 +123,10 @@ int main( int argc, char* argv[] )
             cout << "exiting..." << endl;
             exit( EXIT_FAILURE ) ;
         }
+        if( i < fRunPara->getCutCharacteristicMCAZ().size() )
+        {
+            fCuts.back()->setCutCharacteristicsMCAZ( fRunPara->getCutCharacteristicMCAZ()[i] );
+        }
         fRunPara->fGammaHadronCutSelector = fCuts.back()->getGammaHadronCutSelector();
         fRunPara->fDirectionCutSelector   = fCuts.back()->getDirectionCutSelector();
         fCuts.back()->initializeCuts( -1, fRunPara->fGammaHadronProbabilityFile );
@@ -139,7 +143,7 @@ int main( int argc, char* argv[] )
     
     /////////////////////////////////////////////////////////////////////////////
     // set effective area class
-    VEffectiveAreaCalculator fEffectiveAreaCalculator( fRunPara, fCuts[0] );
+    VEffectiveAreaCalculator fEffectiveAreaCalculator( fRunPara, fCuts );
     
     /////////////////////////////////////////////////////////////////////////////
     // set effective area Monte Carlo histogram class
@@ -450,10 +454,10 @@ int main( int argc, char* argv[] )
         }
     }
     // writing cuts to disk
-    ostringstream cutsname;
-    cutsname << "GammaHadronCuts";
     for( unsigned int i = 0; i < fCuts.size(); i++ )
     {
+        ostringstream cutsname;
+        cutsname << "GammaHadronCuts";
         if( fCuts.size() > 1 )
         {
             cutsname << "_" << i;

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -476,7 +476,8 @@ int main( int argc, char* argv[] )
     {
         iMonteCarloHeader->Write();
     }
-    TTree *i_telconfig = fRunPara->getTelConfigTree();
+    TTree *i_telconfig = 0;
+    if( fRunPara ) fRunPara->getTelConfigTree();
     fOutputfile->cd();
     if( i_telconfig )
     {

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -477,7 +477,7 @@ int main( int argc, char* argv[] )
         iMonteCarloHeader->Write();
     }
     TTree *i_telconfig = 0;
-    if( fRunPara ) fRunPara->getTelConfigTree();
+    if( fRunPara ) i_telconfig = fRunPara->getTelConfigTree();
     fOutputfile->cd();
     if( i_telconfig )
     {

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -402,7 +402,7 @@ int main( int argc, char* argv[] )
             fOutputfile->cd();
             fEffectiveAreaCalculator.getAcceptance_AfterCuts()->Write();
         }
-        if( fEffectiveAreaCalculator.getEventDL2DataTree() )
+        if( fRunPara->fWriteEventdatatrees && fEffectiveAreaCalculator.getEventDL2DataTree() )
         {
                cout << "writing event data trees: (";
                cout << fEffectiveAreaCalculator.getEventDL2DataTree()->GetName();
@@ -413,13 +413,13 @@ int main( int argc, char* argv[] )
                    fEffectiveAreaCalculator.getEventDL2DataTree()->Write();
                }
        }
-       if( fRunPara->fWriteEventdatatrees )
+/*       if( fRunPara->fWriteEventdatatrees )
        {
                if( c )
                {
                    c->Merge(fOutputfile, 0, "keep" );
                }
-        }
+        } */
         for( unsigned int c = 0; c < fCuts.size(); c++ )
         {
             if( fCuts[c]->getMVACutGraphs().size() > 0 )

--- a/src/printRunParameter.cpp
+++ b/src/printRunParameter.cpp
@@ -78,6 +78,44 @@ bool readMeanElevation( TFile *fIn )
     return true;
 }
 
+/*
+ * for CTA: get name of telescope depending on the 
+ * telescope type ID
+ */
+
+string getTelTypeName( ULong64_t ttype )
+{
+
+    if( ttype == 138704810 )
+    {
+        return "LST";
+    }
+    else if( ttype == 201509515
+             || ttype == 201309316
+             || ttype == 909924
+             || ttype == 201511619
+             || ttype == 910224
+             || ttype == 201309316
+             || ttype == 201310418
+             || ttype == 201511619
+             || ttype == 201409917
+             || ttype == 201411019 )
+    {
+        return "SST";
+    }
+    else if( ttype == 10408418
+             || ttype == 10408618
+             || ttype == 10608418 )
+    {
+        return "MST";
+    }
+    else if( ttype == 207308707 )
+    {
+        return "MSCT";
+    }
+    return "NOTELESCOPETYPE";
+}
+
 
 /*
  *  read observing direction and print N (North) or S (South)
@@ -169,7 +207,15 @@ bool readTelescopeTypeNumbers( TFile* fIn, string iPara )
     
     if( iPara == "-nteltypes" )
     {
-        cout << fList_of_Tel_type.size() << endl;
+        cout << fList_of_Tel_type.size();
+        map<ULong64_t, unsigned int >::iterator fList_of_Tel_type_iterator;
+        for( fList_of_Tel_type_iterator = fList_of_Tel_type.begin();
+                fList_of_Tel_type_iterator != fList_of_Tel_type.end();
+                fList_of_Tel_type_iterator++ )
+        {
+            cout << " " << getTelTypeName( fList_of_Tel_type_iterator->first );
+        }
+        cout << endl;
         return true;
     }
     else if( iPara.find( "ntype" ) != string::npos )
@@ -186,37 +232,7 @@ bool readTelescopeTypeNumbers( TFile* fIn, string iPara )
             {
                 if( z == teltypeIndex )
                 {
-                    if( fList_of_Tel_type_iterator->first == 138704810 )
-                    {
-                        cout << "LST" << endl;
-                    }
-                    else if( fList_of_Tel_type_iterator->first == 201509515
-                             || fList_of_Tel_type_iterator->first == 201309316
-                             || fList_of_Tel_type_iterator->first == 909924
-                             || fList_of_Tel_type_iterator->first == 201511619
-                             || fList_of_Tel_type_iterator->first == 910224
-                             || fList_of_Tel_type_iterator->first == 201309316
-                             || fList_of_Tel_type_iterator->first == 201310418
-                             || fList_of_Tel_type_iterator->first == 201511619
-                             || fList_of_Tel_type_iterator->first == 201409917
-                             || fList_of_Tel_type_iterator->first == 201411019 )
-                    {
-                        cout << "SST" << endl;
-                    }
-                    else if( fList_of_Tel_type_iterator->first == 10408418
-                             || fList_of_Tel_type_iterator->first == 10408618
-                             || fList_of_Tel_type_iterator->first == 10608418 )
-                    {
-                        cout << "MST" << endl;
-                    }
-                    else if( fList_of_Tel_type_iterator->first == 207308707 )
-                    {
-                        cout << "MSCT" << endl;
-                    }
-                    else
-                    {
-                        cout << "NOTELESCOPETYPE" << endl;
-                    }
+                    cout << getTelTypeName( fList_of_Tel_type_iterator->first ) << endl;
                     return true;
                 }
                 z++;

--- a/src/testEvndispOutput.cpp
+++ b/src/testEvndispOutput.cpp
@@ -103,6 +103,28 @@ int main( int argc, char* argv[] )
              else if( TelID >= 130 && TelID <= 170 ) checkTelType( TelType, 201409917, fRootFile, TelID );
          }
      }
+     else if( fProduction == "prod5-South-BL-MSTF" )
+     {
+         for( unsigned int i = 0; i < telconfig->GetEntries(); i++ )
+         {
+             telconfig->GetEntry( i );
+
+             if( TelID >= 0 && TelID <= 3 ) checkTelType( TelType, 138704810, fRootFile, TelID );
+             else if( TelID >= 4 && TelID <= 28 ) checkTelType( TelType, 10408618, fRootFile, TelID ); 
+             else if( TelID >= 29 && TelID <= 98 ) checkTelType( TelType, 201409917, fRootFile, TelID );
+          }
+     }
+     else if( fProduction == "prod5-South-BL-MSTN" )
+     {
+         for( unsigned int i = 0; i < telconfig->GetEntries(); i++ )
+         {
+             telconfig->GetEntry( i );
+
+             if( TelID >= 0 && TelID <= 3 ) checkTelType( TelType, 138704810, fRootFile, TelID );
+             else if( TelID >= 4 && TelID <= 73 ) checkTelType( TelType, 201409917, fRootFile, TelID );
+             else if( TelID >= 74 && TelID <= 98 ) checkTelType( TelType, 10608418, fRootFile, TelID ); 
+          }
+     }
      else if( fProduction == "prod5-North" )
      {
          for( unsigned int i = 0; i < telconfig->GetEntries(); i++ )

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -308,7 +308,7 @@ vector< string > fillInputFile_fromList( string iList )
 
     (a previous training session produced these files
 */
-bool readTrainingFile( string iTargetML, ULong64_t iTelType, const string iDataDirectory )
+bool readTrainingFile( string iTargetML, ULong64_t iTelType, string iDataDirectory )
 {
     fMapOfTrainingTree.clear();
     

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -48,22 +48,24 @@ map< ULong64_t, unsigned int > fMapOfNTelescopeType;
 
     one MVA per telescope type
 
-    Allowed target BDTs:
+    Allowed targets for training:
 
     BDTDisp
     BDTDispError
     BDTDispEnergy
     BDTDispCore
 
+    Default is always BDT (but other MLs like MLPs are allowed)
+
 
 */
 bool trainTMVA( string iOutputDir, float iTrainTest,
                 ULong64_t iTelType, TTree* iDataTree,
-                string iTargetBDT, string iTMVAOptions,
+                string iTargetML, string iTMVAOptions,
                 string iQualityCut, bool iSingleTelescopeAnalysis )
 {
     cout << endl;
-    cout << "Starting " << iTargetBDT;
+    cout << "Starting " << iTargetML;
     cout << " training for telescope type " << iTelType << endl;
     cout << "----------------------------------------------------------------" << endl;
     cout << endl;
@@ -121,7 +123,7 @@ bool trainTMVA( string iOutputDir, float iTrainTest,
     
     // output file name
     ostringstream iFileName;
-    iFileName << iOutputDir << "/" << iTargetBDT << "_" << iTelType << ".tmva.root";
+    iFileName << iOutputDir << "/" << iTargetML << "_" << iTelType << ".tmva.root";
     TFile* i_tmva = new TFile( iFileName.str().c_str(), "RECREATE" );
     if( i_tmva->IsZombie() )
     {
@@ -137,7 +139,7 @@ bool trainTMVA( string iOutputDir, float iTrainTest,
     
     
     // tmva regression
-    TMVA::Factory* factory = new TMVA::Factory( iTargetBDT.c_str(), i_tmva, 
+    TMVA::Factory* factory = new TMVA::Factory( iTargetML.c_str(), i_tmva, 
                             "V:!DrawProgressBar:!Color:!Silent:AnalysisType=Regression:VerboseLevel=Debug:Correlations=True" );
     factory->SetVerbose( true );
     TMVA::DataLoader* dataloader = new TMVA::DataLoader( "" );
@@ -161,7 +163,7 @@ bool trainTMVA( string iOutputDir, float iTrainTest,
     dataloader->AddVariable( "loss"  , 'F' );
     dataloader->AddVariable( "dist"  , 'F' );
     dataloader->AddVariable( "fui"  , 'F' );
-    if( iTargetBDT == "BDTDispEnergy" && !iSingleTelescopeAnalysis )
+    if( iTargetML.find( "DispEnergy" ) != string::npos && !iSingleTelescopeAnalysis )
     {
         dataloader->AddVariable( "EHeight", 'F' );
         dataloader->AddVariable( "Rcore", 'F' );
@@ -179,41 +181,36 @@ bool trainTMVA( string iOutputDir, float iTrainTest,
     dataloader->AddSpectator( "MCrcore", 'F' );
     dataloader->AddSpectator( "NImages", 'F' );
     // train for energy reconstruction
-    if( iTargetBDT == "BDTDispEnergy" )
+    if( iTargetML.find( "DispEnergy" ) != string::npos )
     {
         // dispEnergy is log10(E)/log10(size)
         dataloader->AddTarget( "dispEnergy", 'F' );
     }
-    // train for direction reconstruction
-    else if( iTargetBDT == "BDTDisp" )
-    {
-        dataloader->AddSpectator( "dispError", 'F' );
-        dataloader->AddSpectator( "dispPhi", 'F' );
-        dataloader->AddTarget( "disp"  , 'F' );
-    }
     // rotation angle
-    else if( iTargetBDT == "BDTDispPhi" )
+    else if( iTargetML.find( "DispPhi" ) != string::npos )
     {
         dataloader->AddSpectator( "disp", 'F' );
         dataloader->AddSpectator( "dispError", 'F' );
         dataloader->AddTarget( "dispPhi"  , 'F' );
     }
     // train for error on disp reconstruction
-    else if( iTargetBDT == "BDTDispError" )
+    else if( iTargetML.find( "DispError" ) != string::npos )
     {
         dataloader->AddSpectator( "disp", 'F' );
         dataloader->AddSpectator( "dispPhi", 'F' );
         dataloader->AddTarget( "dispError", 'F', "dispError", 0., 10. );
     }
     // train for core reconstruction
-    else if( iTargetBDT == "BDTDispCore" )
+    else if( iTargetML.find( "DispCore" ) != string::npos )
     {
         dataloader->AddTarget( "dispCore"  , 'F', "m", 0., 1.e5 );
     }
+    // train for direction reconstruction
     else
     {
-        cout << "Error: unknown target BDT: " << iTargetBDT << endl;
-        exit( EXIT_FAILURE );
+        dataloader->AddSpectator( "dispError", 'F' );
+        dataloader->AddSpectator( "dispPhi", 'F' );
+        dataloader->AddTarget( "disp"  , 'F' );
     }
     // add weights (optional)
     //    dataloader->SetWeightExpression( "MCe0*MCe0", "Regression" );
@@ -233,7 +230,14 @@ bool trainTMVA( string iOutputDir, float iTrainTest,
     dataloader->PrepareTrainingAndTestTree( fQualityCut, train_and_test_conditions.str().c_str() ) ;
     
     ostringstream iMVAName;
-    iMVAName << "BDT_" << iTelType;
+    if( iTargetML.find( "MLP" ) != string::npos )
+    {
+        iMVAName << "MLP_" << iTelType;
+    }
+    else
+    {
+       iMVAName << "BDT_" << iTelType;
+    }
     sprintf( htitle, "%s", iMVAName.str().c_str() );
     
     TString methodstr( iTMVAOptions.c_str() );
@@ -241,7 +245,14 @@ bool trainTMVA( string iOutputDir, float iTrainTest,
     cout << "Built MethodStringStream: " << iTMVAOptions << endl;
     cout << endl;
     TString methodTitle( htitle );
-    factory->BookMethod( dataloader, TMVA::Types::kBDT, methodTitle, methodstr ) ;
+    if( iTargetML.find( "MLP" ) != string::npos )
+    {
+        factory->BookMethod( dataloader, TMVA::Types::kMLP,  methodTitle, methodstr );
+    }
+    else
+    {
+        factory->BookMethod( dataloader, TMVA::Types::kBDT, methodTitle, methodstr ) ;
+    }
     
     factory->TrainAllMethods();
     
@@ -297,12 +308,12 @@ vector< string > fillInputFile_fromList( string iList )
 
     (a previous training session produced these files
 */
-bool readTrainingFile( string iTargetBDT, ULong64_t iTelType, const string iDataDirectory )
+bool readTrainingFile( string iTargetML, ULong64_t iTelType, const string iDataDirectory )
 {
     fMapOfTrainingTree.clear();
     
     ostringstream iFileName;
-    iFileName << iDataDirectory << "/" << iTargetBDT;
+    iFileName << iDataDirectory << "/" << iTargetML;
     if( iTelType != 0 )
     {
         iFileName << "_" << iTelType;
@@ -892,7 +903,7 @@ int main( int argc, char* argv[] )
     float        fTrainTest  = atof( argv[3] );
     unsigned int iRecID      = atoi( argv[4] );
     ULong64_t    iTelType    = atoi( argv[5] ) ;
-    string       iTargetBDT  = "BDTDisp";
+    string       iTargetML  = "BDTDisp";
     string iTMVAOptions = "VarTransform=N:NTrees=200:BoostType=AdaBoost:MaxDepth=8";
     string       iDataDirectory = "";
     string       iLayoutFile = "";
@@ -900,7 +911,7 @@ int main( int argc, char* argv[] )
     iQualityCut = iQualityCut + "&&tgrad_x<100.*100.&&loss<0.20&&cross<20.0&&Rcore<2000.";
     if( argc >=  7 )
     {
-        iTargetBDT =       argv[6]   ;
+        iTargetML = argv[6];
     }
     if( argc >=  8 )
     {
@@ -918,6 +929,8 @@ int main( int argc, char* argv[] )
     {
         iQualityCut = argv[10];
     }
+    // TMP BDT
+    //iTMVAOptions = "VarTransform=N:NCycles=500:HiddenLayers=36,6:NeuronType=tanh";
     
     ///////////////////////////
     // print runparameters to screen
@@ -951,7 +964,7 @@ int main( int argc, char* argv[] )
     ///////////////////////////
     // output file
     ostringstream iFileName;
-    iFileName << fOutputDir << "/" << iTargetBDT;
+    iFileName << fOutputDir << "/" << iTargetML;
     if( iTelType != 0 )
     {
         iFileName << "_" << iTelType;
@@ -972,7 +985,7 @@ int main( int argc, char* argv[] )
         cout << "exiting..." << endl;
         exit( EXIT_FAILURE );
     }
-    else if( iDataDirectory.size() != 0 && !readTrainingFile( iTargetBDT, iTelType, iDataDirectory ) )
+    else if( iDataDirectory.size() != 0 && !readTrainingFile( iTargetML, iTelType, iDataDirectory ) )
     {
         cout << "error reading training file " << endl;
         cout << "exiting..." << endl;
@@ -1007,7 +1020,7 @@ int main( int argc, char* argv[] )
         trainTMVA( fOutputDir, fTrainTest, 
                 fMapOfTrainingTree_iter->first, 
                 fMapOfTrainingTree_iter->second, 
-                iTargetBDT, iTMVAOptions, iQualityCut, iSingleTel );
+                iTargetML, iTMVAOptions, iQualityCut, iSingleTel );
     }
     
     //////////////////////

--- a/src/trainTMVAforGammaHadronSeparation.cpp
+++ b/src/trainTMVAforGammaHadronSeparation.cpp
@@ -96,7 +96,6 @@ TTree* prepareSelectedEventsTree( VTMVARunData* iRun, TCut iCut,
     Double_t MSCL = 0.;
     Double_t ErecS = 0.;
     Double_t EChi2S = 0.;
-    Double_t dES = 0.;
     // fixed max number of telescope types
     UInt_t NImages_Ttype[20];
     for( unsigned int i = 0; i < 20; i++ ) NImages_Ttype[i] = 0;
@@ -110,7 +109,6 @@ TTree* prepareSelectedEventsTree( VTMVARunData* iRun, TCut iCut,
     iDataTree_reduced->Branch( "MSCL", &MSCL, "MSCL/D" );
     iDataTree_reduced->Branch( "ErecS", &ErecS, "ErecS/D" );
     iDataTree_reduced->Branch( "EChi2S", &EChi2S, "EChi2S/D" );
-    iDataTree_reduced->Branch( "dES", &dES, "dES/D" );
     iDataTree_reduced->Branch( "NImages_Ttype", NImages_Ttype, "NImages_Ttype[20]/i" );
     iDataTree_reduced->Branch( "EmissionHeight", &EmissionHeight, "EmissionHeight/F" );
     iDataTree_reduced->Branch( "EmissionHeightChi2", &EmissionHeightChi2, "EmissionHeightChi2/F" );
@@ -128,7 +126,6 @@ TTree* prepareSelectedEventsTree( VTMVARunData* iRun, TCut iCut,
              iTreeVector[i]->SetBranchAddress( "MSCL", &MSCL );
              iTreeVector[i]->SetBranchAddress( "ErecS", &ErecS );
              iTreeVector[i]->SetBranchAddress( "EChi2S", &EChi2S );
-             iTreeVector[i]->SetBranchAddress( "dES", &dES );
              iTreeVector[i]->SetBranchAddress( "NImages_Ttype", NImages_Ttype );
              iTreeVector[i]->SetBranchAddress( "EmissionHeight", &EmissionHeight );
              iTreeVector[i]->SetBranchAddress( "EmissionHeightChi2", &EmissionHeightChi2 );

--- a/src/trainTMVAforGammaHadronSeparation.cpp
+++ b/src/trainTMVAforGammaHadronSeparation.cpp
@@ -94,6 +94,7 @@ TTree* prepareSelectedEventsTree( VTMVARunData* iRun, TCut iCut,
     // must be at least the variables used for the training
     Double_t MSCW = 0.;
     Double_t MSCL = 0.;
+    Double_t ErecS = 0.;
     Double_t EChi2S = 0.;
     Double_t dES = 0.;
     // fixed max number of telescope types
@@ -107,6 +108,7 @@ TTree* prepareSelectedEventsTree( VTMVARunData* iRun, TCut iCut,
     iDataTree_reduced = new TTree( iDataTree_reducedName.c_str(), iDataTree_reducedName.c_str() );
     iDataTree_reduced->Branch( "MSCW", &MSCW, "MSCW/D" );
     iDataTree_reduced->Branch( "MSCL", &MSCL, "MSCL/D" );
+    iDataTree_reduced->Branch( "ErecS", &ErecS, "ErecS/D" );
     iDataTree_reduced->Branch( "EChi2S", &EChi2S, "EChi2S/D" );
     iDataTree_reduced->Branch( "dES", &dES, "dES/D" );
     iDataTree_reduced->Branch( "NImages_Ttype", NImages_Ttype, "NImages_Ttype[20]/i" );
@@ -124,6 +126,7 @@ TTree* prepareSelectedEventsTree( VTMVARunData* iRun, TCut iCut,
         {
              iTreeVector[i]->SetBranchAddress( "MSCW", &MSCW );
              iTreeVector[i]->SetBranchAddress( "MSCL", &MSCL );
+             iTreeVector[i]->SetBranchAddress( "ErecS", &ErecS );
              iTreeVector[i]->SetBranchAddress( "EChi2S", &EChi2S );
              iTreeVector[i]->SetBranchAddress( "dES", &dES );
              iTreeVector[i]->SetBranchAddress( "NImages_Ttype", NImages_Ttype );
@@ -386,11 +389,13 @@ bool train( VTMVARunData* iRun,
     // quality cuts before training
     TCut iCutSignal = iRun->fQualityCuts && iRun->fQualityCutsSignal 
                    && iRun->fMCxyoffCut && iRun->fAzimuthCut &&
+                   iRun->fMultiplicityCuts &&
                    iRun->fEnergyCutData[iEnergyBin]->fEnergyCut 
                    && iRun->fZenithCutData[iZenithBin]->fZenithCut;
 
     TCut iCutBck = iRun->fQualityCuts && iRun->fQualityCutsBkg 
                 && iRun->fAzimuthCut 
+                && iRun->fMultiplicityCuts
                 && iRun->fEnergyCutData[iEnergyBin]->fEnergyCut
                 && iRun->fZenithCutData[iZenithBin]->fZenithCut;
 
@@ -588,9 +593,15 @@ bool train( VTMVARunData* iRun,
     if( iTrainGammaHadronSeparation )
     {
         cout << "Preparing training and test tree" << endl;
-        TCut sigcut = "";
-        TCut bkgcut = "";
-        dataloader->PrepareTrainingAndTestTree( sigcut, bkgcut, iRun->fPrepareTrainingOptions );
+        // cuts after pre-selection
+        TCut iCutSignal_post = iRun->fEnergyCutData[iEnergyBin]->fEnergyCut
+                            && iRun->fMultiplicityCuts;
+        TCut iCutBck_post = iRun->fEnergyCutData[iEnergyBin]->fEnergyCut
+                            && iRun->fMultiplicityCuts;
+
+        dataloader->PrepareTrainingAndTestTree( iCutSignal_post,
+                                                iCutBck_post, 
+                                                iRun->fPrepareTrainingOptions );
     }
     else
     {

--- a/src/trainTMVAforGammaHadronSeparation.cpp
+++ b/src/trainTMVAforGammaHadronSeparation.cpp
@@ -326,15 +326,32 @@ bool train( VTMVARunData* iRun,
          exit( EXIT_SUCCESS );
      }
     // check for number of training and background events
+     cout << "Reading number of events before / after cuts: " << endl;
      Long64_t nEventsSignal = iSignalTree_reduced->GetEntries();
+     cout << "\t total number of signal events before cuts: ";
+     cout << nEventsSignal << endl;
+     iSignalTree_reduced->Draw( ">>elist", iRun->fEnergyCutData[iEnergyBin]->fEnergyCut && iRun->fMultiplicityCuts, "entrylist" );
+     TEntryList *elist = (TEntryList*)gDirectory->Get("elist");
+     if( elist )
+     {
+         nEventsSignal = elist->GetN();
+         cout << "\t total number of signal events after cuts:  ";
+         cout << elist->GetN();
+         cout << " (required are " << iRun->fMinSignalEvents << ")" << endl;
+     }
      Long64_t nEventsBck = iBackgroundTree_reduced->GetEntries();
-     cout << "Reading number of events after cuts: " << endl;
-     cout << "\t total number of signal events after cuts: ";
-     cout << nEventsSignal;
-     cout << " (required are " << iRun->fMinSignalEvents << ")" << endl;
-     cout << "\t total number of background events after cuts: ";
-     cout << nEventsBck;
-     cout << " (required are " << iRun->fMinBackgroundEvents << ")" << endl;
+     cout << "\t total number of background events before cuts: ";
+     cout << nEventsBck << endl;
+     iBackgroundTree_reduced->Draw( ">>elist", iRun->fEnergyCutData[iEnergyBin]->fEnergyCut && iRun->fMultiplicityCuts, "entrylist" );
+     elist = (TEntryList*)gDirectory->Get("elist");
+     if( elist )
+     {
+         nEventsBck = elist->GetN();
+         cout << "\t total number of background events after cuts:  ";
+         cout << elist->GetN();
+         cout << " (required are " << iRun->fMinSignalEvents << ")" << endl;
+         cout << " (required are " << iRun->fMinBackgroundEvents << ")" << endl;
+     }
      if( nEventsSignal < iRun->fMinSignalEvents || nEventsBck < iRun->fMinBackgroundEvents  )
      {
          cout << "Error: not enough training events" << endl;

--- a/src/writeCTAWPPhysSensitivityFiles.cpp
+++ b/src/writeCTAWPPhysSensitivityFiles.cpp
@@ -76,20 +76,6 @@ int main( int argc, char* argv[] )
     vector< double > iWobbleMax;
     if( fWriteOffsetFiles )
     {
-        // prod2 offsets
-        /* iWobbleMin.push_back( 0.0 );
-        iWobbleMax.push_back( 1.0 );
-        iWobbleMin.push_back( 1.0 );
-        iWobbleMax.push_back( 2.0 );
-        iWobbleMin.push_back( 2.0 );
-        iWobbleMax.push_back( 3.0 );
-        iWobbleMin.push_back( 3.0 );
-        iWobbleMax.push_back( 3.5 );
-        iWobbleMin.push_back( 3.5 );
-        iWobbleMax.push_back( 4.0 );
-        iWobbleMin.push_back( 4.0 );
-        iWobbleMax.push_back( 4.5 );
-        iWobbleMin.push_back( 4.5 ); */
         // prod3 offsets
         if( !bOffAxisFineBinning )
         {

--- a/src/writeVTSWPPhysSensitivityFiles.cpp
+++ b/src/writeVTSWPPhysSensitivityFiles.cpp
@@ -151,12 +151,18 @@ bool fillBackgroundRateHistograms( TH1F* hBckRate, TH1F* hBckRateDeq, double wof
         /////////////////////////////////
         
         // read gamma/hadron cuts from effective area file
-        // note: assume same gamma/hadron cuts applied for effective area generation
+        // note 1: assume same gamma/hadron cuts applied for effective area generation
         //       as for anasum analysis
+        // note 2: assume that all gamma/hadron cuts instances have the same cuts applied
+        //         in off-axis bins
         TFile iFile_effArea( iEffectiveAreaFile.c_str() );
         if( !iFile_effArea.IsZombie() )
         {
             VGammaHadronCuts* i_GammaHadronCuts = ( VGammaHadronCuts* )iFile_effArea.Get( "GammaHadronCuts" );
+            if( !i_GammaHadronCuts )
+            {
+                i_GammaHadronCuts = ( VGammaHadronCuts* )iFile_effArea.Get( "GammaHadronCuts_0" );
+            }
             if( i_GammaHadronCuts )
             {
                 cout << "found gamma/hadron cuts in effective area file" << endl;


### PR DESCRIPTION
This is part of a large pull request to improve the efficiency and stability of the CTA analysis.

### XML files from TMVA

TMVA model is stored in plain XML file taking up a lot of disk space. Use *logFile* binary to pipe them into / out of the corresponding root files used for other data products. XML files are unpacked into the TMPDIR on each node, which might improve disk I/O. 
Required changes of several scripts.

### Average IRFs 

[issue #77](https://github.com/Eventdisplay/Eventdisplay/issues/77)

Average azimuth IRFs did use a MVA model trained with a mixed of events from both azimuth directions. This average model is expected to perform less compared to models trained for the specific directions. Add to the IRF and effective area calculators the possibility to use several (in this case 2 for each az direction) instances of the gamma/hadron cut class and to read the correct mva values for each class. This approach has the additional benefits that no TMVA, and no ANGRES/QC steps are required for the average IRFs, which is a significant reduction in computing and storage needs.
Required significant code changes and changes to several scripts.

### TMVA g/h training optimisation

[issue #81](https://github.com/Eventdisplay/Eventdisplay/issues/81)

TMVA training per energy and off-axis angle for all possible combinations of multiplicity cuts with large impact on computing and storage.

Improvement, Option 1: 
Remove multiplicity-dependent TMVA training.
- calculate signal and background efficiencies for given multiplicity cut in a step before ANGRES (requires application of quality cuts; calculation of MVA values)
- (not implemented; requires additional coding and testing)

Improvement, Option 2 (implemented):
Combine training of all energy bins into one job. TMVA training is quick and requires a few minutes only. The training of the 9 energy bins might fit into a single job.

Improvement, Option 3 (implemented):
Events for the IRF training are pre-selected once and written to disk. Reduces the number of times the mscw_energy trees are access and reduces the execution time of the training steps. Adds one step to the execution chain (PREPARETMVA).

Removed variable checking in trainTMVAforGammaHadronSeparation and dES as a training variable (no visible impact on selection process).

### DL2tree for pyIRF

Optimise the size of the event list (DL2 tree) used for pyIRF. Instead of merging the full data tree, apply a selection of variables and fill everything into one tree. Optimized event tree types.

Tree compression was off in earlier versions of Eventdisplay. Files are larger than before (30-50% for gammas, factor 4-15 for electrons and protons)

###  dispBDT training with MLP

Changed disp training to allow different MLs like NN-MLPs. Required modest changes in scripts and code. MLPs perform similar as BDT, but tests with different hyper parameters and event weighting does not provide better results (worse at the highest energies with small event training statistics) 

### telconfig to Phys file

[issue #76](https://github.com/Eventdisplay/Eventdisplay/issues/76)

Propagate telconfig tree from mscw_energy stage through effective area stages to Phys files.

###  DL2 tree with MVA output (not implemented)

calculate mva value per event use the *fillDL2tree* executable once (note as now for each effective area step). Requires to complete successfully the g/h training optimisation step (removal of multiplicity dependent TMVA g/h models). Would reduce the computing resources; need to understand storage impact.
Not implemented, as MVAs are trained in different angular bins (isotropic MC files contained all simulated events); complicated implementation 
- [issue 91](https://github.com/Eventdisplay/Eventdisplay/issues/91)
- [branch prod5-v10-DL2Writer](https://github.com/Eventdisplay/Eventdisplay/tree/prod5-v10-DL2Writer)