### PR TITLE
Bug fix in elevation / azimuth calculation

### DIFF
--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -183,12 +183,11 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
     //////////////////////////////////////////////////////////
     // calculate (average) angle between the image lines for
     f_angdiff = 0.;
+    float fmean_iangdiffN = 0.;
     
     if( cosphi.size() > 1 )
     {
         // calculate average angle between image lines
-        f_angdiff = 0.;
-        float fmean_iangdiffN = 0.;
         for( unsigned int ii = 0; ii < sinphi.size(); ii++ )
         {
             for( unsigned int jj = 1; jj < sinphi.size(); jj++ )
@@ -226,11 +225,11 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
     {
         f_angdiff = 180.;
     }
-    // check for close to parallel lines
+    // check for close to parallel lines for image multiplicity 2
     // (not so important for disp direction,
     //  but note that core reconstruction
     //  is still done the convential way)
-    if( f_angdiff < fAxesAngles_min )
+    if( f_angdiff < fAxesAngles_min && fmean_iangdiffN < 2.01 )
     {
         return;
     }

--- a/src/VSimpleStereoReconstructor.cpp
+++ b/src/VSimpleStereoReconstructor.cpp
@@ -350,22 +350,22 @@ bool VSimpleStereoReconstructor::reconstruct_direction_and_core( unsigned int i_
 bool VSimpleStereoReconstructor::fillShowerDirection( float xoff, float yoff )
 {
     if( TMath::IsNaN( yoff ) || TMath::IsNaN( yoff )
-            || xoff < -9998. || yoff < -9998. || yoff > 9999.5 )
+            || xoff < -998. || yoff < -998. || yoff > 998. )
     {
         reset();
         return false;
     }
     fShower_Xoffset = xoff;
-    fShower_Yoffset = yoff;
+    fShower_Yoffset = -1.*yoff;
     
     // ze / az
     double ze = 0.;
     double az = 0.;
-    VAstronometry::vlaDtp2s( -1.* fShower_Xoffset*TMath::DegToRad(), 
-                                  fShower_Yoffset*TMath::DegToRad(),
-                                  fTelAzimuth * TMath::DegToRad(),
-                                  fTelElevation * TMath::DegToRad(),
-                                   &az, &ze );
+    VAstronometry::vlaDtp2s( fShower_Xoffset*TMath::DegToRad(), 
+                             fShower_Yoffset*TMath::DegToRad(),
+                             fTelAzimuth * TMath::DegToRad(),
+                             fTelElevation * TMath::DegToRad(),
+                             &az, &ze );
     az *= TMath::RadToDeg();
     ze = 90. - ze * TMath::RadToDeg();
             


### PR DESCRIPTION
This PR addresses a bug in the elevation azimuth calculation in `src/VSimpleStereoReconstructor.cpp` (a simple sign error).

Note that this does not affect any results based on the Eventdisplay analysis, as here `Xoff`, `Yoff` are used only. However, it is relevant for DL2-pased analysis as e.g., pyIRF.
