### PR TITLE
Reconstruction method BDTs

### DIFF
--- a/docs/changes/171.feature.md
+++ b/docs/changes/171.feature.md
@@ -1,6 +1,8 @@
 Improvements to small-array analysis:
 
 - acceptance of loss values > 0.2 and introduction of mitigating steps
-- dispBDTEnergy trains on linear E instead of `TMath::Power( 10., fdisp_energy_T[i] * log10( img_size[i] ) );`
-- energy reconstruction (dispBDTEnergy) uses now dispBDT weight instead of image size**2
+- dispBDTEnergy trains on logE instead of `TMath::Power( 10., fdisp_energy_T[i] * log10( img_size[i] ) );`
+- energy reconstruction (dispBDTEnergy) uses median instead of weighted mean
+- introduce `TRAIN_RECO_QUALITY` and `TRAIN_RECO_METHOD` BDT machine learners
+- improved weight expression for training of dispBDTs
 - (many typo and code layout fixes)

--- a/inc/VDispAnalyzer.h
+++ b/inc/VDispAnalyzer.h
@@ -21,16 +21,16 @@ using namespace std;
 class VDispAnalyzer
 {
     private:
-    
+
         bool                fDebug;
-        
+
         bool                bZombie;
-        
+
         string              fDispMethod;
-        
+
         VDispTableAnalyzer* fDispTableAnalyzer;
         VTMVADispAnalyzer*  fTMVADispAnalyzer;
-        
+
         float fAxesAngles_min;
         unsigned int fNImages_min;
         float fdistance_max;
@@ -39,7 +39,7 @@ class VDispAnalyzer
         bool  fDispErrorWeighting;
         float fDispErrorExponential;
         double* fdistanceQC_max;
-        
+
         // disp direction reconstruction
         float f_disp;
         float f_dispE;
@@ -53,28 +53,27 @@ class VDispAnalyzer
         float fdisp_sum_abs_weigth;
         vector< float > fdisp_T;
         vector< unsigned int > fdisplist_T;
-        
+
         // disp direction error
         vector< float > fdisp_error_T;
-        
+
         // disp energy reconstruction
         float fdisp_energy;
         float fdisp_energy_chi;
         float fdisp_energy_dEs;
-        float fdisp_energy_median;
         float fdisp_energy_medianAbsoluteError;
         vector< float > fdisp_energy_T;
         unsigned int   fdisp_energy_NT;
         int  fdisp_energyQL;
-        
+
         // disp core reconstruction
         vector< float > fdisp_core_T;
-        
+
         vector<ULong64_t> fTelescopeTypeList;
-        
+
         void calculateMeanShowerDirection( vector< float > v_x, vector< float > v_y, vector< float > v_weight,
                                            float& xs, float& ys, float& dispdiff, unsigned int iMaxN );
-                                           
+
         unsigned int find_smallest_diff_element(
             vector< vector< float > > i_sign,
             vector< float > x, vector< float > y,
@@ -82,12 +81,12 @@ class VDispAnalyzer
             vector< float > v_disp, vector< float > v_weight );
         vector< vector< float > > get_sign_permutation_vector( unsigned int x_size );
         vector< unsigned int > get_largest_weight_index( std::vector<float>, unsigned int );
-        
+
     public:
-    
+
         VDispAnalyzer();
         ~VDispAnalyzer() {}
-        
+
         void calculateCore( unsigned int i_ntel, float iArrayElevation, float iArrayAzimuth,
                             double* itelX, double* itelY, double* itelZ,
                             ULong64_t* iTelType,
@@ -101,7 +100,7 @@ class VDispAnalyzer
                             double xcore, double ycore,
                             double xs, double ys,
                             double* img_fui );
-                            
+
         void calculateEnergies( unsigned int i_ntel, float iArrayElevation, float iArrayAzimuth,
                                 ULong64_t* iTelType,
                                 double* img_size, double* img_cen_x, double* img_cen_y,
@@ -113,15 +112,15 @@ class VDispAnalyzer
                                 double* iR, double iEHeight,
                                 double iMCEnergy = -1.,
                                 double* img_fui = 0 );
-                                
+
         void  calculateMeanDirection( float& xs, float& ys,
                                       vector< float > x, vector< float > y,
                                       vector< float > cosphi, vector< float > sinphi,
                                       vector< float > v_disp, vector< float > v_weight,
                                       float& dispdiff,
                                       float x_off4 = -999., float yoff_4 = -999. );
-                                      
-                                      
+
+
         void calculateMeanDirection( unsigned int i_ntel, float iArrayElevation, float iArrayAzimuth,
                                      ULong64_t* iTelType,
                                      double* img_size, double* img_cen_x, double* img_cen_y,
@@ -132,7 +131,7 @@ class VDispAnalyzer
                                      double xoff_4, double yoff_4,
                                      vector< float > dispErrorT,
                                      double* img_fui );
-                                     
+
         void calculateExpectedDirectionError( unsigned int i_ntel, float iArrayElevation, float iArrayAzimuth,
                                               ULong64_t* iTelType,
                                               double* img_size, double* img_cen_x, double* img_cen_y,
@@ -142,7 +141,7 @@ class VDispAnalyzer
                                               double* img_weight,
                                               double xoff_4, double yoff_4,
                                               double* img_fui );
-                                              
+
         float evaluate( float iWidth, float iLength, float iAsymm, float iDist,
                         float iSize, float iPedvar, float itgrad, float iLoss,
                         float icen_x, float icen_y, float xoff_4, float yoff_4, ULong64_t iTelType,
@@ -169,7 +168,6 @@ class VDispAnalyzer
         float getEnergy();
         float getEnergyChi2();
         float getEnergydES();
-        float getEnergyMedian();
         float getEnergyMedianAbsoluteError();
         int   getEnergyQualityLabel()
         {
@@ -180,7 +178,7 @@ class VDispAnalyzer
         {
             return fdisp_energy_NT;
         }
-        
+
         float getXcoordinate_disp()
         {
             return f_xs;

--- a/inc/VTMVARunData.h
+++ b/inc/VTMVARunData.h
@@ -33,26 +33,23 @@ using namespace std;
 class VTMVARunData : public TNamed
 {
     private:
-    
+
         bool              fDebug;
-        
+
     public:
-    
+
         string            fName;
-        
-        // run type
-        bool fTrainGammaHadronSeparation;
-        bool fTrainReconstructionQuality;
-        
+        string fRunMode;
+
         // output file
         string            fOutputFileName;
         string            fOutputDirectoryName;
         vector< vector< TFile* > >  fOutputFile;
-        
+
         // training options
         bool              fCheckValidityOfInputVariables;
         unsigned int      fResetNumberOfTrainingEvents;
-        
+
         // training data
         double            fSignalWeight;
         vector< string >  fSignalFileName;
@@ -61,17 +58,17 @@ class VTMVARunData : public TNamed
         vector< string >  fBackgroundFileName;
         vector< TChain* > fBackgroundTree;
         string            fSelectedEventTreeName;
-        
+
         // list of training variables
         vector< string >  fTrainingVariable;
         vector< char >    fTrainingVariableType;
         vector< float >   fTrainingVariable_CutRangeMin;
         vector< float >   fTrainingVariable_CutRangeMax;
         vector< string >  fTrainingVariable_VarProp;
-        
+
         // spectator variables
         vector< string > fSpectatorVariable;
-        
+
         // quality and energy and zenith cuts
         unsigned int      fMinSignalEvents;
         unsigned int      fMinBackgroundEvents;
@@ -85,18 +82,18 @@ class VTMVARunData : public TNamed
         string            fPrepareTrainingOptions;
         vector< VTMVARunDataEnergyCut* > fEnergyCutData;
         vector< VTMVARunDataZenithCut* > fZenithCutData;
-        
+
         // analysis variables
         int               fNTtype;
-        
+
         // MVA methods
         vector< string >  fMVAMethod;
         vector< string >  fMVAMethod_Options;
-        
+
         // reconstruction quality target
         string            fReconstructionQualityTarget;
         string            fReconstructionQualityTargetName;
-        
+
         VTMVARunData();
         ~VTMVARunData() {}
         void print();
@@ -112,8 +109,9 @@ class VTMVARunData : public TNamed
             fName = iN;
         }
         void shuffleFileVectors();
-        
-        ClassDef( VTMVARunData, 14 );
+        string test_run_mode(string irun_mode);
+
+        ClassDef( VTMVARunData, 15 );
 };
 
 #endif

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -782,6 +782,7 @@ void VDispAnalyzer::calculateEnergies( unsigned int i_ntel,
 
     ////////////////////////////////////////////
     // calculate for each image an energy
+    //
 
     // counter for good energy values
     float z = 0.;
@@ -866,7 +867,7 @@ void VDispAnalyzer::calculateEnergies( unsigned int i_ntel,
     // therefore: get rid of N sigma outliers
     // use robust statistics (median and median absolute error)
     // Note: applied only to larger events > 4 telescopes
-    fdisp_energy_median = TMath::Median( energy_tel.size(), &energy_tel[0] );
+    fdisp_energy_median = TMath::Median( energy_tel.size(), energy_tel.data() );
     fdisp_energy_medianAbsoluteError = VStatistics::getMedianAbsoluteError( energy_tel, fdisp_energy_median );
     double w = 0.;
     unsigned int n2 = 0;

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -804,6 +804,8 @@ void VDispAnalyzer::calculateEnergies( unsigned int i_ntel,
                                     ( float )sqrt( img_cen_x[i] * img_cen_x[i] + img_cen_y[i] * img_cen_y[i] ),
                                     ( float )img_fui[i], ( float )img_ntubes[i] );
 
+            fdisp_energy_T[i] = TMath::Power( 10., fdisp_energy_T[i] );
+
             if( fDebug )
             {
                 cout << "VDispAnalyzer::calculateEnergies: tel " << i << " (teltype " << ( ULong64_t )iTelType[i] << ") ";

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -545,7 +545,8 @@ void VDispAnalyzer::calculateMeanDirection( unsigned int i_ntel,
                 && sqrt( img_cen_x[i]*img_cen_x[i] + img_cen_y[i]*img_cen_y[i] ) < fdistance_max
                 && img_loss[i] < floss_max
                 && img_fui[i] > fFui_min
-                && ( fdistanceQC_max == 0 || sqrt( img_cen_x[i]*img_cen_x[i] + img_cen_y[i]*img_cen_y[i] ) < fdistanceQC_max[i] ) )
+                && ( fdistanceQC_max == 0 || sqrt( img_cen_x[i]*img_cen_x[i] + img_cen_y[i]*img_cen_y[i] ) < fdistanceQC_max[i] )
+                && xoff_4 > -999. && yoff_4 > -999. )
         {
             disp = evaluate( ( float )img_width[i], ( float )img_length[i], ( float )img_asym[i],
                              ( float )sqrt( img_cen_x[i] * img_cen_x[i] + img_cen_y[i] * img_cen_y[i] ),
@@ -673,7 +674,8 @@ void VDispAnalyzer::calculateExpectedDirectionError( unsigned int i_ntel,
                 && sqrt( img_cen_x[i]*img_cen_x[i] + img_cen_y[i]*img_cen_y[i] ) < fdistance_max
                 && img_loss[i] < floss_max
                 && img_fui[i] > fFui_min
-                && ( fdistanceQC_max == 0 || sqrt( img_cen_x[i]*img_cen_x[i] + img_cen_y[i]*img_cen_y[i] ) < fdistanceQC_max[i] ) )
+                && ( fdistanceQC_max == 0 || sqrt( img_cen_x[i]*img_cen_x[i] + img_cen_y[i]*img_cen_y[i] ) < fdistanceQC_max[i] )
+                && xoff_4 > -999. && yoff_4 > -999. )
         {
             fdisp_error_T[i] = evaluate( ( float )img_width[i], ( float )img_length[i], ( float )img_asym[i],
                                          ( float )sqrt( img_cen_x[i] * img_cen_x[i] + img_cen_y[i] * img_cen_y[i] ),
@@ -792,7 +794,8 @@ void VDispAnalyzer::calculateEnergies( unsigned int i_ntel,
                 && sqrt( img_cen_x[i]*img_cen_x[i] + img_cen_y[i]*img_cen_y[i] ) < fdistance_max
                 && img_loss[i] < floss_max
                 && img_fui[i] > fFui_min
-                && ( fdistanceQC_max == 0 || sqrt( img_cen_x[i]*img_cen_x[i] + img_cen_y[i]*img_cen_y[i] ) < fdistanceQC_max[i] ) )
+                && ( fdistanceQC_max == 0 || sqrt( img_cen_x[i]*img_cen_x[i] + img_cen_y[i]*img_cen_y[i] ) < fdistanceQC_max[i] )
+                && xoff_4 > -999. && yoff_4 > -999. )
         {
             fdisp_energy_T[i] = fTMVADispAnalyzer->evaluate(
                                     ( float )img_width[i], ( float )img_length[i],

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -182,17 +182,17 @@ unsigned int VDispAnalyzer::find_smallest_diff_element(
 {
     vector< float > v_disp_diff( i_sign.size(), 0. );
     vector< float > v_dist( i_sign.size(), 0. );
+    vector< float > v_xs( x.size(), 0. );
+    vector< float > v_ys( x.size(), 0. );
+    float xs = 0.;
+    float ys = 0.;
+    float disp_diff = 0.;
     for( unsigned int s = 0; s < i_sign.size(); s++ )
     {
-        vector< float > v_xs;
-        vector< float > v_ys;
-        float xs = 0.;
-        float ys = 0.;
-        float disp_diff = 0.;
         for( unsigned int i = 0; i < x.size(); i++ )
         {
-            v_xs.push_back( x[i] - i_sign[s][i] * v_disp[i] * cosphi[i] );
-            v_ys.push_back( y[i] - i_sign[s][i] * v_disp[i] * sinphi[i] );
+            v_xs[i] = x[i] - i_sign[s][i] * v_disp[i] * cosphi[i];
+            v_ys[i] = y[i] - i_sign[s][i] * v_disp[i] * sinphi[i];
         }
         calculateMeanShowerDirection( v_xs, v_ys, v_weight, xs, ys, disp_diff, v_xs.size() );
         v_disp_diff[s] = disp_diff;
@@ -411,7 +411,7 @@ void VDispAnalyzer::calculateMeanDirection( float& xs, float& ys,
         calculateMeanShowerDirection( fdisp_xs_T, fdisp_ys_T, v_weight, xs, ys, dispdiff, fdisp_xs_T.size() );
     }
 
-    // apply a completely unnecessary sign flip
+    // apply sign flip
     if( ys > -9998. )
     {
         ys *= -1.;
@@ -783,7 +783,6 @@ void VDispAnalyzer::calculateEnergies( unsigned int i_ntel,
 
     ////////////////////////////////////////////
     // calculate for each image an energy
-    //
 
     // counter for good energy values
     float z = 0.;

--- a/src/VDispAnalyzer.cpp
+++ b/src/VDispAnalyzer.cpp
@@ -28,7 +28,6 @@ VDispAnalyzer::VDispAnalyzer()
     fdisp_energy = -9999.;
     fdisp_energy_chi = -9999.;
     fdisp_energy_dEs = -9999.;
-    fdisp_energy_median = -9999.;
     fdisp_energy_medianAbsoluteError = -9999.;
     fdisp_energy_NT = 0;
     fdisp_energyQL = -1;
@@ -768,6 +767,8 @@ void VDispAnalyzer::calculateEnergies( unsigned int i_ntel,
     fdisp_energy_NT = 0;
     fdisp_energyQL = -1;
 
+    fDebug = true;
+
     // make sure that all data arrays exist
     if( !img_size || !img_cen_x || !img_cen_y
             || !img_cosphi || !img_sinphi
@@ -849,7 +850,8 @@ void VDispAnalyzer::calculateEnergies( unsigned int i_ntel,
             energy_tel.push_back( fdisp_energy_T[i] );
             // Weighting with size leads to a long tail towards large eres/mce0
             //              energy_weight.push_back( img_size[i] * img_weight[i] * img_size[i] * img_weight[i] );
-            energy_weight.push_back( img_weight[i] * img_weight[i] );
+            // dispError is smallest for best reconstruction results
+            energy_weight.push_back( 1./ img_weight[i] * 1. / img_weight[i] );
             if( fDebug )
             {
                 iR.push_back( iRcore[i] );
@@ -867,34 +869,21 @@ void VDispAnalyzer::calculateEnergies( unsigned int i_ntel,
     // therefore: get rid of N sigma outliers
     // use robust statistics (median and median absolute error)
     // Note: applied only to larger events > 4 telescopes
-    fdisp_energy_median = TMath::Median( energy_tel.size(), energy_tel.data() );
-    fdisp_energy_medianAbsoluteError = VStatistics::getMedianAbsoluteError( energy_tel, fdisp_energy_median );
-    double w = 0.;
-    unsigned int n2 = 0;
-    fdisp_energy = 0.;
-    for( unsigned int j = 0; j < energy_tel.size(); j++ )
+    fdisp_energy = TMath::Median( energy_tel.size(), energy_tel.data(), energy_weight.data() );
+    fdisp_energy_medianAbsoluteError = VStatistics::getMedianAbsoluteError( energy_tel, fdisp_energy );
+    fdisp_energy_NT = energy_tel.size();
+    if( fDebug )
     {
-        if( energy_tel.size() < 5
-                || TMath::Abs( energy_tel[j] - fdisp_energy_median ) < fdisp_energy_medianAbsoluteError * 3. )
+        cout << "VDispAnalyzer::calculateEnergies: " << fdisp_energy <<  " from " << fdisp_energy_NT << " energies";
+        cout << " (true energy: " << iMCEnergy << " / " << fdisp_energy / iMCEnergy << ")" << endl;
+        for( unsigned int j = 0; j < energy_tel.size(); j++ )
         {
-            fdisp_energy += energy_tel[j] * energy_weight[j];
-            w += energy_weight[j];
-            n2++;
+            cout << "\t " << energy_tel[j] << " weight: " << energy_weight[j] << endl;
         }
     }
-    fdisp_energy_NT = energy_tel.size();
-    // check minimum number of valid energies
-    /*     if( energy_tel.size() <= 4 && w > 0. )
-         {
-             fdisp_energy /= w;
-             fdisp_energy_NT = n2;
-         }  */
-    // use median for energy estimation (removes outliers)
-    // (for all cases)
-    if( n2 >= fNImages_min )
+    if( fdisp_energy_NT >= fNImages_min )
     {
-        fdisp_energy = fdisp_energy_median;
-        if( n2 == 1 )
+        if( fdisp_energy_NT == 1 )
         {
             fdisp_energyQL = 1;
         }
@@ -955,11 +944,6 @@ float VDispAnalyzer::getEnergyChi2()
 float VDispAnalyzer::getEnergydES()
 {
     return fdisp_energy_dEs;
-}
-
-float VDispAnalyzer::getEnergyMedian()
-{
-    return fdisp_energy_median;
 }
 
 float VDispAnalyzer::getEnergyMedianAbsoluteError()

--- a/src/VSimpleStereoReconstructor.cpp
+++ b/src/VSimpleStereoReconstructor.cpp
@@ -32,17 +32,17 @@ void VSimpleStereoReconstructor::reset()
 {
 
     fiangdiff = 0.;
-    fShower_Xoffset = -9999.;
-    fShower_Yoffset = -9999.;
-    fShower_stdS = -9999.;
-    fShower_Chi2 = -9999.;
-    fShower_Ze = -9999.;
-    fShower_Az = -9999.;
-    fShower_DispDiff = -9999.;
-    
-    fShower_Xcore = -9999.;
-    fShower_Ycore = -9999.;
-    fShower_stdP = -9999.;
+    fShower_Xoffset = -99999.;
+    fShower_Yoffset = -99999.;
+    fShower_stdS = -99999.;
+    fShower_Chi2 = -99999.;
+    fShower_Ze = -99999.;
+    fShower_Az = -99999.;
+    fShower_DispDiff = -99999.;
+
+    fShower_Xcore = -99999.;
+    fShower_Ycore = -99999.;
+    fShower_stdP = -99999.;
     fmean_iangdiff = 0.;
 }
 
@@ -57,8 +57,6 @@ void VSimpleStereoReconstructor::reset()
       direction and image centroids
 
       corresponds to rcs_method4 in VArrayAnalyzer
-
-      should be used for MC only
 
 */
 bool VSimpleStereoReconstructor::reconstruct_direction_and_core( unsigned int i_ntel,
@@ -79,7 +77,7 @@ bool VSimpleStereoReconstructor::reconstruct_direction_and_core( unsigned int i_
     // telescope pointings
     fTelElevation = iArrayElevation;
     fTelAzimuth   = iArrayAzimuth;
-    
+
     // make sure that all data arrays exist
     if( !img_size || !img_cen_x || !img_cen_y
             || !img_cosphi || !img_sinphi
@@ -89,10 +87,10 @@ bool VSimpleStereoReconstructor::reconstruct_direction_and_core( unsigned int i_
         reset();
         return false;
     }
-    
+
     float xs = 0.;
     float ys = 0.;
-    
+
     // fill data vectors for direction reconstruction
     // (vectors are refilled for core reconstruction)
     vector< float > m;
@@ -135,7 +133,7 @@ bool VSimpleStereoReconstructor::reconstruct_direction_and_core( unsigned int i_
         reset();
         return false;
     }
-    
+
     // don't do anything if angle between image axis is too small (for 2 images only)
     if( w.size() == 2 )
     {
@@ -145,13 +143,13 @@ bool VSimpleStereoReconstructor::reconstruct_direction_and_core( unsigned int i_
     {
         fiangdiff = 0.;
     }
-    
+
     ///////////////////////////////
     // direction reconstruction
     ////////////////////////////////////////////////
     // Hofmann et al 1999, Method 1 (HEGRA method)
     // (modified weights)
-    
+
     float itotweight = 0.;
     float iweight = 1.;
     float ixs = 0.;
@@ -163,7 +161,7 @@ bool VSimpleStereoReconstructor::reconstruct_direction_and_core( unsigned int i_
     vector< float > v_ys;
     fmean_iangdiff = 0.;
     float fmean_iangdiffN = 0.;
-    
+
     for( unsigned int ii = 0; ii < m.size(); ii++ )
     {
         for( unsigned int jj = 1; jj < m.size(); jj++ )
@@ -172,7 +170,7 @@ bool VSimpleStereoReconstructor::reconstruct_direction_and_core( unsigned int i_
             {
                 continue;
             }
-            
+
             // check minimum angle between image lines; ignore if too small
             iangdiff = fabs( atan( m[jj] ) - atan( m[ii] ) );
             if( iangdiff < fAxesAngles_min * TMath::DegToRad() ||
@@ -190,13 +188,13 @@ bool VSimpleStereoReconstructor::reconstruct_direction_and_core( unsigned int i_
                 fmean_iangdiff += ( 180. - iangdiff * TMath::RadToDeg() );
             }
             fmean_iangdiffN++;
-            
+
             // weight is sin of angle between image lines
             iangdiff = fabs( sin( fabs( atan( m[jj] ) - atan( m[ii] ) ) ) );
-            
+
             b1 = y[ii] - m[ii] * x[ii];
             b2 = y[jj] - m[jj] * x[jj];
-            
+
             // line intersection
             if( m[ii] != m[jj] )
             {
@@ -207,16 +205,16 @@ bool VSimpleStereoReconstructor::reconstruct_direction_and_core( unsigned int i_
                 xs = 0.;
             }
             ys = m[ii] * xs + b1;
-            
+
             iweight  = 1. / ( 1. / w[ii] + 1. / w[jj] ); // weight 1: size of images
             iweight *= ( 1. - l[ii] ) * ( 1. - l[jj] ); // weight 2: elongation of images (width/length)
             iweight *= iangdiff;                      // weight 3: angular differences between the two image axis
             iweight *= iweight;                       // use squared value
-            
+
             ixs += xs * iweight;
             iys += ys * iweight;
             itotweight += iweight;
-            
+
             v_xs.push_back( xs );
             v_ys.push_back( ys );
         }
@@ -269,7 +267,7 @@ bool VSimpleStereoReconstructor::reconstruct_direction_and_core( unsigned int i_
         fShower_Yoffset = -99999.;
         fShower_DispDiff = -999999.;
     }
-    
+
     // fill correct shower direction
     // do not continue with core reconstruction in case there is no valid
     // direction reconstruction
@@ -278,28 +276,28 @@ bool VSimpleStereoReconstructor::reconstruct_direction_and_core( unsigned int i_
     {
         return false;
     }
-    
+
     ////////////////////////////////////////////////
     // core reconstruction
     ////////////////////////////////////////////////
-    
+
     // calculated telescope positions in shower coordinates
     float i_xcos = sin( ( 90. - fTelElevation ) / TMath::RadToDeg() ) * sin( ( fTelAzimuth - 180. ) / TMath::RadToDeg() );
     float i_ycos = sin( ( 90. - fTelElevation ) / TMath::RadToDeg() ) * cos( ( fTelAzimuth - 180. ) / TMath::RadToDeg() );
     float i_xrot, i_yrot, i_zrot = 0.;
-    
+
     float ximp = 0.;
     float yimp = 0.;
     float stdp = 0.;
-    
+
     float i_cenx = 0.;
     float i_ceny = 0.;
-    
+
     x.clear();
     y.clear();
     m.clear();
     w.clear();
-    
+
     for( unsigned int i = 0; i < i_ntel; i++ )
     {
         if( img_size[i] > 0. && img_length[i] > 0. )
@@ -307,12 +305,9 @@ bool VSimpleStereoReconstructor::reconstruct_direction_and_core( unsigned int i_
             // telescope coordinates
             // shower coordinates (telecope pointing)
             tel_impact( i_xcos, i_ycos, iTelX[i], iTelY[i], iTelZ[i], &i_xrot, &i_yrot, &i_zrot, false );
-            // shower coordinates (shower direction)
-            // x.push_back( iTelX[i] - ixs / TMath::RadToDeg() * iTelZ[i] );
-            // y.push_back( iTelY[i] - iys / TMath::RadToDeg() * iTelZ[i] );
             x.push_back( i_xrot - ixs / TMath::RadToDeg() * i_zrot );
             y.push_back( i_yrot - iys / TMath::RadToDeg() * i_zrot );
-            
+
             // gradient of image
             i_cenx = img_cen_x[i] - ixs;
             i_ceny = img_cen_y[i] - iys;
@@ -330,16 +325,16 @@ bool VSimpleStereoReconstructor::reconstruct_direction_and_core( unsigned int i_
             w.push_back( iweight * iweight );
         }
     }
-    
+
     // Now call perpendicular_distance for the fit, returning ximp and yimp
     rcs_perpendicular_fit( x, y, w, m, ( int )w.size(), &ximp, &yimp, &stdp );
-    
+
     // return to ground coordinates
     fillShowerCore( ximp, yimp );
     fShower_stdP = stdp;
-    
+
     fShower_Chi2 = 0.;
-    
+
     return true;
 }
 
@@ -357,7 +352,7 @@ bool VSimpleStereoReconstructor::fillShowerDirection( float xoff, float yoff )
     }
     fShower_Xoffset = xoff;
     fShower_Yoffset = yoff;
-    
+
     // ze / az
     double ze = 0.;
     double az = 0.;
@@ -368,14 +363,14 @@ bool VSimpleStereoReconstructor::fillShowerDirection( float xoff, float yoff )
                              &az, &ze );
     az *= TMath::RadToDeg();
     ze = 90. - ze * TMath::RadToDeg();
-    
+
     if( TMath::IsNaN( ze ) )
     {
         fShower_Ze = -99999.;
     }
     fShower_Ze = ze;
     fShower_Az = VAstronometry::vlaDranrm( az * TMath::DegToRad() ) * TMath::RadToDeg();
-    
+
     return true;
 }
 
@@ -388,8 +383,8 @@ bool VSimpleStereoReconstructor::fillShowerCore( float ximp, float yimp )
     // check validity
     if( !isnormal( ximp ) || !isnormal( yimp ) )
     {
-        ximp = -99999.;
-        yimp = -99999.;
+        fShower_Xcore = -99999.;
+        fShower_Ycore = -99999.;
         return false;
     }
     // reconstructed shower core in ground coordinates
@@ -422,6 +417,7 @@ bool VSimpleStereoReconstructor::fillShowerCore( float ximp, float yimp )
     {
         fShower_Xcore = -99999;
         fShower_Ycore = -99999;
+        return false;
     }
     return true;
 }

--- a/src/VTMVARunData.cpp
+++ b/src/VTMVARunData.cpp
@@ -263,7 +263,7 @@ bool VTMVARunData::openDataFiles( bool iCheckMinEvents )
 */
 string VTMVARunData::test_run_mode( string irun_mode )
 {
-    if( irun_mode != "TrainGammaHadronSeparation" && irun_mode != "TrainReconstructionQuality" && irun_mode != "TrainAngularReconstructionMethod" )
+    if( irun_mode != "TrainGammaHadronSeparation" && irun_mode != "TrainReconstructionQuality" && irun_mode != "TrainAngularReconstructionMethod" && irun_mode != "WriteTrainingEvents" )
     {
         cout << "Invalid run mode: " << irun_mode << endl;
         exit( EXIT_FAILURE );

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -754,7 +754,7 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
             fXoff, fYoff,
             getDistanceToCore(),
             fXcore, fYcore,
-            fXoff, fYoff,
+            fXoff_intersect, fYoff_intersect,
             ffui );
 
         // fill results
@@ -767,11 +767,8 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
     }
 
     //////////////////////////////////////////////////////////
-    // !!! SPECIAL AND EXPERT USAGE ONLY !!!
     // dispEnergy
     // energy reconstruction using the disp MVA
-    // This is preliminary and works for MC events only!
-    //
     if( fDispAnalyzerEnergy )
     {
         fDispAnalyzerEnergy->setQualityCuts( fSSR_NImages_min, fSSR_AxesAngles_min,
@@ -790,7 +787,7 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
             fasym, ftgrad_x,
             floss, fntubes,
             getWeight(true),
-            fXoff, fYoff,
+            fXoff_intersect, fYoff_intersect,
             getDistanceToCoreTel(),
             fEmissionHeightMean,
             fMCEnergy,

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -754,7 +754,7 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
             fXoff, fYoff,
             getDistanceToCore(),
             fXcore, fYcore,
-            fXoff_intersect, fYoff_intersect,
+            fXoff_edisp, fYoff_edisp,
             ffui );
 
         // fill results
@@ -787,7 +787,7 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
             fasym, ftgrad_x,
             floss, fntubes,
             getWeight(true),
-            fXoff_intersect, fYoff_intersect,
+            fXoff_edisp, fYoff_edisp,
             getDistanceToCoreTel(),
             fEmissionHeightMean,
             fMCEnergy,
@@ -838,6 +838,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
     fXoff_intersect = i_SR.fShower_Xoffset;
     fYoff_intersect = i_SR.fShower_Yoffset;
 
+
     ////////////////////////////////////////////////////////////////////
     // DISP method for updated disp reconstruction
     ////////////////////////////////////////////////////////////////////
@@ -861,7 +862,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
                 fasym, ftgrad_x,
                 floss, fntubes,
                 getWeight(),
-                i_SR.fShower_Xoffset, i_SR.fShower_Yoffset,
+                fXoff_edisp, fYoff_edisp,
                 ffui );
 
             // get estimated error on direction reconstruction
@@ -891,7 +892,7 @@ void VTableLookupDataHandler::doStereoReconstruction()
             fasym, ftgrad_x,
             floss, fntubes,
             getWeight(),
-            i_SR.fShower_Xoffset, i_SR.fShower_Yoffset,
+            fXoff_edisp, fYoff_edisp,
             iDispError, ffui );
         // reconstructed direction by disp method:
         fimg2_ang = fDispAnalyzerDirection->getAngDiff();

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -815,14 +815,9 @@ int VTableLookupDataHandler::fillNextEvent( bool bShort )
 }
 
 /*
- * redo stereo reconstruction (core and direction)
+ * Stereo reconstruction (core and direction)
  *
- * this works for MC only
- * not all stereo reconstruction methods are implemented
- * (quick and dirty implementation for CTA)
- *
- * does not take into account pointing corrections
- * (as e.g. given by the VPM)
+ * using geometrical and disp methods
 */
 void VTableLookupDataHandler::doStereoReconstruction()
 {
@@ -831,9 +826,8 @@ void VTableLookupDataHandler::doStereoReconstruction()
     fYoff_edisp = fYoff;
     ///////////////////////////
     // stereo reconstruction
-    // (rcs_method4)
+    // (equivalent to rcs_method4)
     VSimpleStereoReconstructor i_SR;
-    // minimal value; just used to initialize disp method
     i_SR.initialize( fSSR_NImages_min, fSSR_AxesAngles_min );
     i_SR.reconstruct_direction_and_core( getNTel(),
                                          fArrayPointing_Elevation, fArrayPointing_Azimuth,
@@ -853,12 +847,10 @@ void VTableLookupDataHandler::doStereoReconstruction()
     if( fDispAnalyzerDirection
             && fNImages <= ( int )fTLRunParameter->fRerunStereoReconstruction_BDTNImages_max )
     {
-
-        vector< float > iDispError( getNTel(), -9999. );
-
         ////////////////////////////////////////////////////////////////////
         // estimate error on direction reconstruction from DISP method
         ////////////////////////////////////////////////////////////////////
+        vector< float > iDispError( getNTel(), -9999. );
         if( fDispAnalyzerDirectionError )
         {
             fDispAnalyzerDirectionError->calculateExpectedDirectionError(
@@ -1138,6 +1130,7 @@ bool VTableLookupDataHandler::setInputFile( vector< string > iInput )
     fList_of_Tel_type.clear();
     if( fTtelconfig )
     {
+        fTelFOV.clear();
         ftelconfig = new Ctelconfig( fTtelconfig );
         ftelconfig->GetEntry( 0 );
         fNTel = ftelconfig->NTel;

--- a/src/VTableLookupDataHandler.cpp
+++ b/src/VTableLookupDataHandler.cpp
@@ -1130,7 +1130,6 @@ bool VTableLookupDataHandler::setInputFile( vector< string > iInput )
     fList_of_Tel_type.clear();
     if( fTtelconfig )
     {
-        fTelFOV.clear();
         ftelconfig = new Ctelconfig( fTtelconfig );
         ftelconfig->GetEntry( 0 );
         fNTel = ftelconfig->NTel;

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -205,7 +205,7 @@ bool trainTMVA( string iOutputDir, float iTrainTest,
         dataloader->AddTarget( "disp", 'F' );
     }
     // add weights (optional)
-    //    dataloader->SetWeightExpression( "MCe0*MCe0", "Regression" );
+    dataloader->SetWeightExpression( "MCe0", "Regression" );
 
     // regression tree
     dataloader->AddRegressionTree( iDataTree, 1. );

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -919,7 +919,7 @@ bool writeTrainingFile( const string iInputFile, ULong64_t iTelType,
                                        +  dlength* dlength );
             }
 
-            dispEnergy = i_showerpars.MCe0;
+            dispEnergy = log10(i_showerpars.MCe0);
             dispCore   = Rcore;
 
             if( fMapOfTrainingTree.find( fTelType[i] ) != fMapOfTrainingTree.end() )

--- a/src/trainTMVAforAngularReconstruction.cpp
+++ b/src/trainTMVAforAngularReconstruction.cpp
@@ -1024,7 +1024,7 @@ int main( int argc, char* argv[] )
     string iWeightExpression = "";
     if( argc >= 12 )
     {
-        iWeightExpression = argv[10];
+        iWeightExpression = argv[11];
     }
     bool iUseImageParameterErrors = false;
     if( argc >= 13 )

--- a/src/trainTMVAforGammaHadronSeparation.cpp
+++ b/src/trainTMVAforGammaHadronSeparation.cpp
@@ -305,14 +305,6 @@ bool train( VTMVARunData* iRun,
                                   iCutBck, false,
                                   iRun->fResetNumberOfTrainingEvents );
 
-        if( iSignalTree_reduced )
-        {
-            iSignalTree_reduced->Write();
-        }
-        if( iBackgroundTree_reduced )
-        {
-            iBackgroundTree_reduced->Write();
-        }
         if( iRun->getTLRunParameter() )
         {
             iRun->getTLRunParameter()->Write();

--- a/src/trainTMVAforGammaHadronSeparation.cpp
+++ b/src/trainTMVAforGammaHadronSeparation.cpp
@@ -401,29 +401,21 @@ bool train( VTMVARunData* iRun,
     // train for angular reconstruction method
     else if( iRunMode == "TrainAngularReconstructionMethod" )
     {
-        cout << "START " << endl;
         TString d1 = "sqrt((Xoff_derot - MCxoff)^2 + (Yoff_derot - MCyoff)^2)";
         TString d2 = "sqrt((Xoff_intersect - MCxoff)^2 + (Yoff_intersect - MCyoff)^2)";
 
         TCut signalCut = Form("(Xoff_intersect > -90 && Yoff_intersect > -90) && (%s > %s)", d1.Data(), d2.Data());
         TCut backgrCut = Form("(%s) < (%s)", d1.Data(), d2.Data());
 
+        iRun->fOutputFile[iEnergyBin][iZenithBin]->cd();
+
         TTree* sigTree = iSignalTree_reduced->CopyTree(signalCut);
         TTree* bkgTree = iSignalTree_reduced->CopyTree(backgrCut);
-        cout << "A " << sigTree->GetEntries() << endl;
-        cout << "B " << bkgTree->GetEntries() << endl;
         sigTree->SetName("data_signal");
         bkgTree->SetName("data_background");
-        sigTree->SetDirectory(iRun->fOutputFile[iEnergyBin][iZenithBin]);
-        bkgTree->SetDirectory(iRun->fOutputFile[iEnergyBin][iZenithBin]);
 
         dataloader->AddSignalTree(sigTree, iRun->fSignalWeight);
         dataloader->AddBackgroundTree(bkgTree, iRun->fBackgroundWeight);
-/*	cout << "A " << signalCut << endl;
-#	cout << "B " << backgrCut << endl;
-#	cout << iSignalTree_reduced->GetEntries() << endl;
-#        dataloader->SetInputTrees( iSignalTree_reduced, signalCut, backgrCut ); */
-	exit(0);
     }
     ////////////////////////////
     // train reconstruction quality
@@ -447,24 +439,16 @@ bool train( VTMVARunData* iRun,
     //////////////////////////////////////////
     // prepare training events
     // (cuts are already applied at an earlier stage)
-    if( iRunMode == "TrainGammaHadronSeparation" )
-    {
-        cout << "Preparing training and test tree" << endl;
-        // cuts after pre-selection
-        TCut iCutSignal_post = iRun->fEnergyCutData[iEnergyBin]->fEnergyCut
-                               && iRun->fMultiplicityCuts;
-        TCut iCutBck_post = iRun->fEnergyCutData[iEnergyBin]->fEnergyCut
-                            && iRun->fMultiplicityCuts;
+    cout << "Preparing training and test tree" << endl;
+    // cuts after pre-selection
+    TCut iCutSignal_post = iRun->fEnergyCutData[iEnergyBin]->fEnergyCut
+                           && iRun->fMultiplicityCuts;
+    TCut iCutBck_post = iRun->fEnergyCutData[iEnergyBin]->fEnergyCut
+                        && iRun->fMultiplicityCuts;
 
-        dataloader->PrepareTrainingAndTestTree( iCutSignal_post,
-                                                iCutBck_post,
-                                                iRun->fPrepareTrainingOptions );
-    }
-    // TODO check if cuts need to be applied
-    else
-    {
-        dataloader->PrepareTrainingAndTestTree( "", iRun->fPrepareTrainingOptions );
-    }
+    dataloader->PrepareTrainingAndTestTree( iCutSignal_post,
+                                            iCutBck_post,
+                                            iRun->fPrepareTrainingOptions );
 
     //////////////////////////////////////////
     // book all methods

--- a/src/trainTMVAforGammaHadronSeparation.cpp
+++ b/src/trainTMVAforGammaHadronSeparation.cpp
@@ -574,11 +574,8 @@ bool train( VTMVARunData* iRun, unsigned int iEnergyBin, unsigned int iZenithBin
     // train for angular reconstruction method
     else if( iRunMode == "TrainAngularReconstructionMethod" )
     {
-        TString d1 = "sqrt((Xoff_derot - MCxoff)^2 + (Yoff_derot - MCyoff)^2)";
-        TString d2 = "sqrt((Xoff_intersect - MCxoff)^2 + (Yoff_intersect - MCyoff)^2)";
-
-        TCut signalCut = Form("(Xoff_intersect > -90 && Yoff_intersect > -90) && (%s > %s)", d1.Data(), d2.Data());
-        TCut backgrCut = Form("(%s) < (%s)", d1.Data(), d2.Data());
+        TCut signalCut = "intersect_mc_error < 1.e5 && (disp_mc_error > intersect_mc_error)";
+        TCut backgrCut = "disp_mc_error < intersect_mc_error";
 
         iRun->fOutputFile[iEnergyBin][iZenithBin]->cd();
 
@@ -601,7 +598,14 @@ bool train( VTMVARunData* iRun, unsigned int iEnergyBin, unsigned int iZenithBin
     // loop over all trainingvariables and add them to TMVA
     for( unsigned int i = 0; i < iRun->fTrainingVariable.size(); i++ )
     {
-        dataloader->AddVariable( iRun->fTrainingVariable[i].c_str(), iRun->fTrainingVariableType[i] );
+        if( iRun->fTrainingVariable[i].rfind("d_", 0 ) == 0 )
+        {
+            dataloader->AddVariablesArray(iRun->fTrainingVariable[i].c_str(), 4 );
+        }
+        else
+        {
+            dataloader->AddVariable( iRun->fTrainingVariable[i].c_str(), iRun->fTrainingVariableType[i] );
+        }
     }
     // adding spectator variables
     for( unsigned int i = 0; i < iRun->fSpectatorVariable.size(); i++ )

--- a/src/trainTMVAforGammaHadronSeparation.cpp
+++ b/src/trainTMVAforGammaHadronSeparation.cpp
@@ -130,7 +130,7 @@ bool get_largest_weight_disp_entries(
     for (unsigned int i = 0; i < entries_to_copy; ++i) {
         unsigned int original_index = indexed_disp_woff[i].second;
 
-        d_size[i] = size[original_index];
+        d_size[i] = log10(size[original_index]);
         d_width[i] = width[original_index];
         d_length[i] = length[original_index];
         d_cross[i] = cross[original_index];
@@ -139,6 +139,8 @@ bool get_largest_weight_disp_entries(
         d_loss[i] = loss[original_index];
         d_R[i] = R[original_index];
         d_erec_mc[i] = (ES[original_index] - ErecS) / ES[original_index];
+        if( d_erec_mc[i] > 20. ) d_erec_mc[i] = 20.;
+        if( d_erec_mc[i] > -20. ) d_erec_mc[i] = -20.;
     }
 
     // --- Step 3: Handle DispNImages < d_n (duplicate values) ---
@@ -243,7 +245,7 @@ TTree* prepareSelectedEventsTree( VTMVARunData* iRun, TCut iCut,
     Float_t d_disp_weigth[d_n];
     Float_t d_loss[d_n];
     Float_t d_R[d_n];
-    Float_t d_erec_emc[d_n];
+    Float_t d_erec_es[d_n];
 
     char htemp[200];
 
@@ -280,8 +282,8 @@ TTree* prepareSelectedEventsTree( VTMVARunData* iRun, TCut iCut,
     iDataTree_reduced->Branch( "d_loss", d_loss, htemp );
     sprintf( htemp, "d_R[%d]/F", d_n );
     iDataTree_reduced->Branch( "d_R", d_R, htemp );
-    sprintf( htemp, "d_erec_emc[%d]/F", d_n );
-    iDataTree_reduced->Branch( "d_erec_emc", d_erec_emc, htemp );
+    sprintf( htemp, "d_erec_es[%d]/F", d_n );
+    iDataTree_reduced->Branch( "d_erec_es", d_erec_es, htemp );
 
 
     Long64_t n = 0;
@@ -348,7 +350,7 @@ TTree* prepareSelectedEventsTree( VTMVARunData* iRun, TCut iCut,
                     bool good_event = get_largest_weight_disp_entries(
                            d_n, DispNImages, NImages, DispTelList_T, ImgSel_list,
                            disp_weight, disp, cross, loss, size, width, length, R, ES, ErecS,
-                           d_size, d_width, d_length, d_cross, d_disp, d_disp_weigth, d_loss, d_erec_emc, d_R
+                           d_size, d_width, d_length, d_cross, d_disp, d_disp_weigth, d_loss, d_erec_es, d_R
                     );
                     if( !good_event )
                     {

--- a/src/trainTMVAforGammaHadronSeparation.cpp
+++ b/src/trainTMVAforGammaHadronSeparation.cpp
@@ -409,8 +409,11 @@ bool train( VTMVARunData* iRun,
     // train for angular reconstruction method
     else if( iRunMode == "TrainAngularReconstructionMethod" )
     {
-        TCut signalCut = "sqrt((Xoff_derot-MCxoff)*(Xoff_derot-MCxoff)+((Yoff_derot-MCyoff)*(Yoff_derot-MCyoff))) < sqrt((Xoff_intersect-MCxoff)*(Xoff_intersect-MCxoff)+((Yoff_intersect-MCyoff)*(Yoff_intersect-MCyoff)))";
-        TCut backgrCut = "sqrt((Xoff_derot-MCxoff)*(Xoff_derot-MCxoff)+((Yoff_derot-MCyoff)*(Yoff_derot-MCyoff))) > sqrt((Xoff_intersect-MCxoff)*(Xoff_intersect-MCxoff)+((Yoff_intersect-MCyoff)*(Yoff_intersect-MCyoff)))";
+        TString d1 = "sqrt((Xoff_derot - MCxoff)^2 + (Yoff_derot - MCyoff)^2)";
+        TString d2 = "sqrt((Xoff_intersect - MCxoff)^2 + (Yoff_intersect - MCyoff)^2)";
+
+        TCut signalCut = Form("(Xoff_intersect > -90 && Yoff_intersect > -90) && (%s > %s)", d1.Data(), d2.Data());
+        TCut backgrCut = Form("(%s) < (%s)", d1.Data(), d2.Data());
         dataloader->SetInputTrees( iSignalTree_reduced, signalCut, backgrCut );
     }
     ////////////////////////////


### PR DESCRIPTION
Introduce:

- a BDT to decide per event which of the two reconstruction methods (dispBDTs or intersection) is better suited for this particle event
- re-iterate on the very old methods training on event quality

Introduce a per-telescope variable selection of the 4 largest weights.