### PR TITLE
v5.17.0 dev2 - add functionality to read XGB stereo results

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,24 @@
 repos:
   # https://pycqa.github.io/isort/docs/configuration/black_compatibility.html#integration-with-pre-commit
   - repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+    rev: 7.0.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.1.0
     hooks:
       - id: black
         args: ["--line-length=100"]
   # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#flake8
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.2.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         args: ["--max-line-length=100", "--extend-ignore=E203,E712"]
   # https://github.com/pre-commit/pre-commit-hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -26,7 +26,7 @@ repos:
       - id: check-shebang-scripts-are-executable
   # gitup action
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.7
+    rev: v1.7.10
     hooks:
       - id: actionlint
   # codespell

--- a/docs/changes/186.feature.md
+++ b/docs/changes/186.feature.md
@@ -1,0 +1,1 @@
+Add support for reading XGB stereo reconstruction results (as friend trees). Effective area / IRF production can use now XGB stereo direction and energy.

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -31,22 +31,22 @@ using namespace std;
 //       e.g. for direction, should it be the disp result, or the classical result
 //       (note that not all reconstruction types are still available today)
 ////////////////////////////////////////////////////////////////////////////////
-enum E_ReconstructionType { NOT_SET = -1, GEO = 0, FROGSDIR = 1, FROGS = 2, MODEL3D = 3, ENERGY_ER = 4, NN = 5, TL = 6, DEEPLEARNER = 7 };
+enum E_ReconstructionType { NOT_SET = -1, GEO = 0, FROGSDIR = 1, FROGS = 2, MODEL3D = 3, ENERGY_ER = 4, NN = 5, TL = 6, DEEPLEARNER = 7, XGBSTEREO=8};
 
 
 class CData
 {
 
     public :
-    
+
         E_ReconstructionType  fReconstructionType ;
         bool            fMC;
         bool            fDeepLearner;
-        
+
         bool            fShort;
         TTree*          fChain;                   //!pointer to the analyzed TTree or TChain
         Int_t           fCurrent;                 //!current Tree number in a TChain
-        
+
         // Declaration of leave types
         Int_t           runNumber;
         Int_t           eventNumber;
@@ -75,7 +75,7 @@ class CData
         Int_t	       MCCorsikaShowerID;
         Float_t        MCFirstInteractionHeight;
         Float_t	       MCFirstInteractionDepth;
-        
+
         ULong64_t       LTrig;
         UInt_t          NTrig;
         Int_t           NImages;
@@ -162,7 +162,7 @@ class CData
         // Deep Learner Parameters
         Double_t         dl_gammaness;
         Bool_t         dl_isGamma;
-        
+
         // List of branches
         TBranch*        b_runNumber;              //!
         TBranch*        b_eventNumber;            //!
@@ -191,7 +191,7 @@ class CData
         TBranch*        b_MCCorsikaShowerID;      //!
         TBranch*        b_MCFirstInteractionHeight;    //!
         TBranch*        b_MCFirstInteractionDepth;     //!
-        
+
         TBranch*        b_LTrig;                  //!
         TBranch*        b_NTrig;                  //!
         TBranch*        b_NImages;                //!
@@ -271,8 +271,13 @@ class CData
         // deep learner parameters
         TBranch*        b_dl_gammaness;             //!
         TBranch*        b_dl_isGamma;             //!
-        
-        CData( TTree* tree = 0, bool bMC = false, bool bShort = false );
+
+        bool            fHasStereoFriendTree;
+        float           Dir_Xoff;                 //!
+        float           Dir_Yoff;                 //!
+        float           Dir_Erec;                 //!
+
+        CData( TTree* tree = 0, bool bMC = false, bool bShort = false, string file_name = "", string stereo_suffix = "" );
         virtual ~CData();
         virtual Int_t    Cut( Long64_t entry );
         virtual Int_t    GetEntry( Long64_t entry );
@@ -292,7 +297,7 @@ class CData
         void setReconstructionType( E_ReconstructionType type )
         {
             fReconstructionType  = type;
-            
+
             // general check if analysis types
             if( fReconstructionType != GEO
                     && fReconstructionType != NN
@@ -398,7 +403,7 @@ class CData
             }
             return EChi2S;
         }
-        
+
         double getEnergyDelta()
         {
             if( fReconstructionType  == ENERGY_ER )
@@ -430,12 +435,12 @@ class CData
         {
             return ImgSel;
         }
-        
+
         UInt_t* getImgSel_list()
         {
             return ImgSel_list; //preliminary
         }
-        
+
         double getZe()
         {
             return Ze;
@@ -464,20 +469,27 @@ class CData
             }
             return n;
         }
-        
-        
+
+
 };
 #endif
 
 #ifdef CData_cxx
 
-CData::CData( TTree* tree, bool bMC, bool bShort )
+CData::CData( TTree* tree, bool bMC, bool bShort, string file_name, string stereo_suffix )
 {
     fMC = bMC;
     fShort = bShort;
     fDeepLearner = false;
     fReconstructionType = GEO;
+    fHasStereoFriendTree = false;
     Init( tree );
+    if( stereo_suffix.size() > 0 )
+    {
+        string friend_file_name = file_name.substr( 0, file_name.find_last_of( "." ) ) + "." + stereo_suffix + ".root";
+        tree->AddFriend( "StereoAnalysis", friend_file_name.c_str() );
+        fHasStereoFriendTree = true;
+    }
 }
 
 
@@ -498,9 +510,9 @@ Int_t CData::GetEntry( Long64_t entry )
     {
         return 0;
     }
-    
+
     int a = fChain->GetEntry( entry );
-    
+
     return a;
 }
 
@@ -539,7 +551,7 @@ void CData::Init( TTree* tree )
     {
         return;
     }
-    
+
     // test if this is a MC file
     if( tree->GetBranchStatus( "MCe0" ) )
     {
@@ -550,10 +562,10 @@ void CData::Init( TTree* tree )
     {
         fDeepLearner = true;
     }
-    
+
     fChain = tree;
     fCurrent = -1;
-    
+
     fChain->SetBranchAddress( "runNumber", &runNumber );
     fChain->SetBranchAddress( "eventNumber", &eventNumber );
     if( !fShort )
@@ -579,7 +591,7 @@ void CData::Init( TTree* tree )
             TelAzimuth[0] = 0.;
         }
     }
-    
+
     if( fChain->GetBranchStatus( "ArrayPointing_Azimuth" ) )
     {
         fChain->SetBranchAddress( "ArrayPointing_Azimuth", &ArrayPointing_Azimuth );
@@ -609,7 +621,7 @@ void CData::Init( TTree* tree )
             TelRA[i] = 0.;
         }
     }
-    
+
     // MC tree
     if( fMC )
     {
@@ -672,10 +684,10 @@ void CData::Init( TTree* tree )
         MCFirstInteractionHeight = 0;
         MCFirstInteractionDepth = 0;
         MCCorsikaRunID = 0;
-        
+
     }
-    
-    
+
+
     if( fChain->GetBranchStatus( "LTrig" ) )
     {
         fChain->SetBranchAddress( "LTrig", &LTrig );
@@ -741,7 +753,7 @@ void CData::Init( TTree* tree )
     {
         Yoff_intersect = 0.;
     }
-    
+
     if( fChain->GetBranchStatus( "stdS" ) )
     {
         fChain->SetBranchAddress( "stdS", &stdS );
@@ -777,7 +789,7 @@ void CData::Init( TTree* tree )
     {
         stdP = 0.;
     }
-    
+
     fChain->SetBranchAddress( "Chi2", &Chi2 );
     if( fChain->GetBranchStatus( "meanPedvar_Image" ) )
     {
@@ -798,9 +810,9 @@ void CData::Init( TTree* tree )
             meanPedvar_ImageT[i] = 0.;
         }
     }
-    
+
     fChain->SetBranchAddress( "SizeSecondMax", &SizeSecondMax );
-    
+
     if( fChain->GetBranchStatus( "theta2_All" ) )
     {
         fChain->SetBranchAddress( "theta2_All", &theta2_All );
@@ -812,7 +824,7 @@ void CData::Init( TTree* tree )
             theta2_All[dex] = 99.0;
         }
     }
-    
+
     if( fChain->GetBranchStatus( "NTtype" ) )
     {
         fChain->SetBranchAddress( "ImgSel_list", ImgSel_list );
@@ -865,8 +877,8 @@ void CData::Init( TTree* tree )
             cross[i] = 0.;
         }
     }
-    
-    
+
+
     if( !fShort )
     {
         if( fChain->GetBranchStatus( "size2" ) )
@@ -1058,7 +1070,7 @@ void CData::Init( TTree* tree )
         dl_gammaness = 0.;
         dl_isGamma = 0;
     }
-    
+
     Notify();
 }
 
@@ -1068,10 +1080,10 @@ Bool_t CData::Notify()
     // The Notify() function is called when a new file is opened. This
     // can be either for a new TTree in a TChain or when when a new TTree
     // is started when using PROOF. Typically here the branch pointers
-    // will be retrieved. It is normaly not necessary to make changes
+    // will be retrieved. It is normally not necessary to make changes
     // to the generated code, but the routine can be extended by the
     // user if needed.
-    
+
     // Get branch pointers
     b_runNumber = fChain->GetBranch( "runNumber" );
     b_eventNumber = fChain->GetBranch( "eventNumber" );
@@ -1083,7 +1095,7 @@ Bool_t CData::Notify()
     b_TelAzimuth = fChain->GetBranch( "TelAzimuth" );
     b_TelDec = fChain->GetBranch( "TelDec" );
     b_TelRA = fChain->GetBranch( "TelRA" );
-    
+
     if( fMC )
     {
         b_MCprimary = fChain->GetBranch( "MCprimary" );
@@ -1103,7 +1115,7 @@ Bool_t CData::Notify()
         b_MCFirstInteractionHeight = fChain->GetBranch( "MCFirstInteractionHeight" );
         b_MCFirstInteractionDepth = fChain->GetBranch( "MCFirstInteractionDepth" );
     }
-    
+
     b_LTrig = fChain->GetBranch( "LTrig" );
     b_NTrig = fChain->GetBranch( "NTrig" );
     b_NImages = fChain->GetBranch( "NImages" );
@@ -1129,9 +1141,9 @@ Bool_t CData::Notify()
     b_Chi2 = fChain->GetBranch( "Chi2" );
     b_meanPedvar_Image = fChain->GetBranch( "meanPedvar_Image" );
     b_meanPedvar_ImageT = fChain->GetBranch( "meanPedvar_ImageT" );
-    
+
     b_SizeSecondMax = fChain->GetBranch( "SizeSecondMax" );
-    
+
     b_theta2_All = fChain->GetBranch( "theta2_All" );
     b_dist = fChain->GetBranch( "dist" );
     b_size = fChain->GetBranch( "size" );
@@ -1208,7 +1220,7 @@ Bool_t CData::Notify()
         b_dl_gammaness = 0;
         b_dl_isGamma = 0;
     }
-    
+
     return kTRUE;
 }
 
@@ -1231,7 +1243,7 @@ Int_t CData::Cut( Long64_t entry )
     // returns  1 if entry is accepted.
     // returns -1 otherwise.
     entry = 0;
-    
+
     return 1;
 }
 #endif                                            // #ifdef CData_cxx

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -1106,9 +1106,9 @@ void CData::Init( TTree* tree )
         dl_isGamma = 0;
     }
 
-    fDir_Xoff = -99.;
-    fDir_Yoff = -99.;
-    fDir_Erec = -99.;
+    Dir_Xoff = -99.;
+    Dir_Yoff = -99.;
+    Dir_Erec = -99.;
 
     Notify();
 }

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -18,6 +18,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <glob.h>
 #include <string>
 #include <assert.h>
 
@@ -519,6 +520,24 @@ CData::CData( TTree* tree, bool bMC, bool bShort, string file_name, string stere
     if( stereo_suffix.size() > 0 )
     {
         string friend_file_name = file_name.substr( 0, file_name.find_last_of( "." ) ) + "." + stereo_suffix + ".root";
+
+        // Expand wildcards if present
+        if( friend_file_name.find( "*" ) != string::npos )
+        {
+            glob_t glob_result;
+            glob( friend_file_name.c_str(), GLOB_NOSORT, NULL, &glob_result );
+            if( glob_result.gl_pathc > 0 )
+            {
+                friend_file_name = glob_result.gl_pathv[0];
+                globfree( &glob_result );
+            }
+            else
+            {
+                globfree( &glob_result );
+                return;  // No file matching pattern found
+            }
+        }
+
         tree->AddFriend( "StereoAnalysis", friend_file_name.c_str() );
         fHasStereoFriendTree = true;
         tree->SetBranchAddress( "StereoAnalysis.Dir_Xoff", &Dir_Xoff );

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -24,6 +24,34 @@
 
 using namespace std;
 
+void PrintCurrentFiles(TTree* tree)
+{
+    auto* chain = dynamic_cast<TChain*>(tree);
+    if (!chain) return;
+
+    // main chain
+    TFile* mainFile = chain->GetCurrentFile();
+    std::cout << "Main file: "
+              << (mainFile ? mainFile->GetName() : "none")
+              << std::endl;
+
+    // friends
+    if (auto* fl = chain->GetListOfFriends())
+    {
+        for (auto* obj : *fl)
+        {
+            auto* tf = static_cast<TFriendElement*>(obj);
+            auto* fchain = dynamic_cast<TChain*>(tf->GetTree());
+            if (!fchain) continue;
+
+            TFile* friendFile = fchain->GetCurrentFile();
+            std::cout << "  Friend (" << tf->GetName() << "): "
+                      << (friendFile ? friendFile->GetName() : "none")
+                      << std::endl;
+        }
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // reconstruction types
 // note: reconstruction types determine which values are written from the mscw root
@@ -566,6 +594,7 @@ Int_t CData::GetEntry( Long64_t entry )
     }
 
     int a = fChain->GetEntry( entry );
+    PrintCurrentFiles(fChain);
 
     return a;
 }
@@ -1304,4 +1333,7 @@ Int_t CData::Cut( Long64_t entry )
 
     return 1;
 }
+
 #endif                                            // #ifdef CData_cxx
+                                                  //
+                                                  //

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -314,15 +314,15 @@ class CData
         }
         double getEnergy_TeV()
         {
-            if( fReconstructionType  == ENERGY_ER )
+            if( fReconstructionType == ENERGY_ER )
             {
                 return Erec;
             }
-            if( fReconstructionType  == GEO )
+            if( fReconstructionType == GEO )
             {
                 return ErecS;
             }
-            if( fReconstructionType  == XGBSTEREO )
+            if( fReconstructionType == XGBSTEREO )
             {
                 return Dir_Erec;
             }
@@ -333,7 +333,7 @@ class CData
         }
         double getEnergy_Log10()
         {
-            if( fReconstructionType  == ENERGY_ER )
+            if( fReconstructionType == ENERGY_ER )
             {
                 if( Erec <= 0 )
                 {
@@ -366,7 +366,7 @@ class CData
         }
         double getXcore_M()
         {
-            if( fReconstructionType  == ENERGY_ER )
+            if( fReconstructionType == ENERGY_ER )
             {
                 return Xcore;
             }
@@ -374,7 +374,7 @@ class CData
         }
         double getYcore_M()
         {
-            if( fReconstructionType  == ENERGY_ER )
+            if( fReconstructionType == ENERGY_ER )
             {
                 return Ycore;
             }
@@ -382,11 +382,11 @@ class CData
         }
         double getXoff()
         {
-            if( fReconstructionType  == ENERGY_ER )
+            if( fReconstructionType == ENERGY_ER )
             {
                 return Xoff;
             }
-            if( fReconstructionType  == XGBSTEREO )
+            if( fReconstructionType == XGBSTEREO )
             {
                 return Dir_Xoff;
             }
@@ -394,11 +394,11 @@ class CData
         }
         double getYoff()
         {
-            if( fReconstructionType  == ENERGY_ER )
+            if( fReconstructionType == ENERGY_ER )
             {
                 return Yoff;
             }
-            if( fReconstructionType  == XGBSTEREO )
+            if( fReconstructionType == XGBSTEREO )
             {
                 return Dir_Yoff;
             }
@@ -406,11 +406,11 @@ class CData
         }
         double getXoff_derot()
         {
-            if( fReconstructionType  == ENERGY_ER )
+            if( fReconstructionType == ENERGY_ER )
             {
                 return Xoff_derot;
             }
-            if( fReconstructionType  == XGBSTEREO )
+            if( fReconstructionType == XGBSTEREO )
             {
                 return Dir_Xoff;
             }
@@ -418,11 +418,11 @@ class CData
         }
         double getYoff_derot()
         {
-            if( fReconstructionType  == ENERGY_ER )
+            if( fReconstructionType == ENERGY_ER )
             {
                 return Yoff_derot;
             }
-            if( fReconstructionType  == XGBSTEREO )
+            if( fReconstructionType == XGBSTEREO )
             {
                 return Dir_Yoff;
             }
@@ -430,7 +430,7 @@ class CData
         }
         double getEnergyChi2()
         {
-            if( fReconstructionType  == ENERGY_ER )
+            if( fReconstructionType == ENERGY_ER )
             {
                 return EChi2;
             }
@@ -439,7 +439,7 @@ class CData
 
         double getEnergyDelta()
         {
-            if( fReconstructionType  == ENERGY_ER )
+            if( fReconstructionType == ENERGY_ER )
             {
                 return dE;
             }

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -24,34 +24,6 @@
 
 using namespace std;
 
-void PrintCurrentFiles(TTree* tree)
-{
-    auto* chain = dynamic_cast<TChain*>(tree);
-    if (!chain) return;
-
-    // main chain
-    TFile* mainFile = chain->GetCurrentFile();
-    std::cout << "Main file: "
-              << (mainFile ? mainFile->GetName() : "none")
-              << std::endl;
-
-    // friends
-    if (auto* fl = chain->GetListOfFriends())
-    {
-        for (auto* obj : *fl)
-        {
-            auto* tf = static_cast<TFriendElement*>(obj);
-            auto* fchain = dynamic_cast<TChain*>(tf->GetTree());
-            if (!fchain) continue;
-
-            TFile* friendFile = fchain->GetCurrentFile();
-            std::cout << "  Friend (" << tf->GetName() << "): "
-                      << (friendFile ? friendFile->GetName() : "none")
-                      << std::endl;
-        }
-    }
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // reconstruction types
 // note: reconstruction types determine which values are written from the mscw root
@@ -306,7 +278,7 @@ class CData
         float           Dir_Yoff;                 //!
         float           Dir_Erec;                 //!
 
-        CData( TTree* tree = 0, bool bMC = false, bool bShort = false, string file_name = "", string stereo_suffix = "" );
+        CData( TTree* tree = 0, bool bMC = false, bool bShort = false );
         virtual ~CData();
         virtual Int_t    Cut( Long64_t entry );
         virtual Int_t    GetEntry( Long64_t entry );
@@ -537,7 +509,7 @@ class CData
 
 #ifdef CData_cxx
 
-CData::CData( TTree* tree, bool bMC, bool bShort, string file_name, string stereo_suffix )
+CData::CData( TTree* tree, bool bMC, bool bShort)
 {
     fMC = bMC;
     fShort = bShort;
@@ -545,33 +517,6 @@ CData::CData( TTree* tree, bool bMC, bool bShort, string file_name, string stere
     fReconstructionType = GEO;
     fHasStereoFriendTree = false;
     Init( tree );
-    if( stereo_suffix.size() > 0 )
-    {
-        string friend_file_name = file_name.substr( 0, file_name.find_last_of( "." ) ) + "." + stereo_suffix + ".root";
-
-        // Expand wildcards if present
-        if( friend_file_name.find( "*" ) != string::npos )
-        {
-            glob_t glob_result;
-            glob( friend_file_name.c_str(), GLOB_NOSORT, NULL, &glob_result );
-            if( glob_result.gl_pathc > 0 )
-            {
-                friend_file_name = glob_result.gl_pathv[0];
-                globfree( &glob_result );
-            }
-            else
-            {
-                globfree( &glob_result );
-                return;  // No file matching pattern found
-            }
-        }
-
-        tree->AddFriend( "StereoAnalysis", friend_file_name.c_str() );
-        fHasStereoFriendTree = true;
-        tree->SetBranchAddress( "StereoAnalysis.Dir_Xoff", &Dir_Xoff );
-        tree->SetBranchAddress( "StereoAnalysis.Dir_Yoff", &Dir_Yoff );
-        tree->SetBranchAddress( "StereoAnalysis.Dir_Erec", &Dir_Erec );
-    }
 }
 
 
@@ -594,7 +539,6 @@ Int_t CData::GetEntry( Long64_t entry )
     }
 
     int a = fChain->GetEntry( entry );
-    PrintCurrentFiles(fChain);
 
     return a;
 }
@@ -1154,9 +1098,18 @@ void CData::Init( TTree* tree )
         dl_isGamma = 0;
     }
 
-    Dir_Xoff = -99.;
-    Dir_Yoff = -99.;
-    Dir_Erec = -99.;
+    if( tree->GetBranchStatus("StereoAnalysis.Dir_Xoff") )
+    {
+        tree->SetBranchAddress( "StereoAnalysis.Dir_Xoff", &Dir_Xoff );
+        tree->SetBranchAddress( "StereoAnalysis.Dir_Yoff", &Dir_Yoff );
+        tree->SetBranchAddress( "StereoAnalysis.Dir_Erec", &Dir_Erec );
+    }
+    else
+    {
+        Dir_Xoff = -99.;
+        Dir_Yoff = -99.;
+        Dir_Erec = -99.;
+    }
 
     Notify();
 }

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -18,7 +18,6 @@
 
 #include <cstdlib>
 #include <iostream>
-#include <glob.h>
 #include <string>
 #include <assert.h>
 

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -272,7 +272,6 @@ class CData
         TBranch*        b_dl_gammaness;             //!
         TBranch*        b_dl_isGamma;             //!
 
-        bool            fHasStereoFriendTree;
         float           Dir_Xoff;                 //!
         float           Dir_Yoff;                 //!
         float           Dir_Erec;                 //!
@@ -514,7 +513,6 @@ CData::CData( TTree* tree, bool bMC, bool bShort)
     fShort = bShort;
     fDeepLearner = false;
     fReconstructionType = GEO;
-    fHasStereoFriendTree = false;
     Init( tree );
 }
 

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -31,7 +31,7 @@ using namespace std;
 //       e.g. for direction, should it be the disp result, or the classical result
 //       (note that not all reconstruction types are still available today)
 ////////////////////////////////////////////////////////////////////////////////
-enum E_ReconstructionType { NOT_SET = -1, GEO = 0, FROGSDIR = 1, FROGS = 2, MODEL3D = 3, ENERGY_ER = 4, NN = 5, TL = 6, DEEPLEARNER = 7, XGBSTEREO=8};
+enum E_ReconstructionType { NOT_SET = -1, GEO = 0, FROGSDIR = 1, FROGS = 2, MODEL3D = 3, ENERGY_ER = 4, NN = 5, TL = 6, DEEPLEARNER = 7, XGBSTEREO = 8};
 
 
 class CData

--- a/inc/CData.h
+++ b/inc/CData.h
@@ -303,7 +303,8 @@ class CData
                     && fReconstructionType != NN
                     && fReconstructionType != TL
                     && fReconstructionType != ENERGY_ER
-                    && fReconstructionType != DEEPLEARNER )
+                    && fReconstructionType != DEEPLEARNER
+                    && fReconstructionType != XGBSTEREO )
             {
                 cout << "CData::setReconstructionType Error: unknown analysis type: ";
                 cout << fReconstructionType << endl;
@@ -319,6 +320,10 @@ class CData
             if( fReconstructionType  == GEO )
             {
                 return ErecS;
+            }
+            if( fReconstructionType  == XGBSTEREO )
+            {
+                return Dir_Erec;
             }
             else
             {
@@ -336,6 +341,17 @@ class CData
                 else
                 {
                     return log10( Erec );
+                }
+            }
+            if( fReconstructionType == XGBSTEREO )
+            {
+                if( Dir_Erec <= 0 )
+                {
+                    return -99;
+                }
+                else
+                {
+                    return log10( Dir_Erec );
                 }
             }
             if( ErecS <= 0 )
@@ -369,6 +385,10 @@ class CData
             {
                 return Xoff;
             }
+            if( fReconstructionType  == XGBSTEREO )
+            {
+                return Dir_Xoff;
+            }
             return Xoff;
         }
         double getYoff()
@@ -376,6 +396,10 @@ class CData
             if( fReconstructionType  == ENERGY_ER )
             {
                 return Yoff;
+            }
+            if( fReconstructionType  == XGBSTEREO )
+            {
+                return Dir_Yoff;
             }
             return Yoff;
         }
@@ -385,6 +409,10 @@ class CData
             {
                 return Xoff_derot;
             }
+            if( fReconstructionType  == XGBSTEREO )
+            {
+                return Dir_Xoff;
+            }
             return Xoff_derot;
         }
         double getYoff_derot()
@@ -392,6 +420,10 @@ class CData
             if( fReconstructionType  == ENERGY_ER )
             {
                 return Yoff_derot;
+            }
+            if( fReconstructionType  == XGBSTEREO )
+            {
+                return Dir_Yoff;
             }
             return Yoff_derot;
         }
@@ -489,6 +521,9 @@ CData::CData( TTree* tree, bool bMC, bool bShort, string file_name, string stere
         string friend_file_name = file_name.substr( 0, file_name.find_last_of( "." ) ) + "." + stereo_suffix + ".root";
         tree->AddFriend( "StereoAnalysis", friend_file_name.c_str() );
         fHasStereoFriendTree = true;
+        tree->SetBranchAddress( "StereoAnalysis.Dir_Xoff", &Dir_Xoff );
+        tree->SetBranchAddress( "StereoAnalysis.Dir_Yoff", &Dir_Yoff );
+        tree->SetBranchAddress( "StereoAnalysis.Dir_Erec", &Dir_Erec );
     }
 }
 
@@ -1070,6 +1105,10 @@ void CData::Init( TTree* tree )
         dl_gammaness = 0.;
         dl_isGamma = 0;
     }
+
+    fDir_Xoff = -99.;
+    fDir_Yoff = -99.;
+    fDir_Erec = -99.;
 
     Notify();
 }

--- a/inc/VEvndispRunParameter.h
+++ b/inc/VEvndispRunParameter.h
@@ -10,6 +10,7 @@
 #define VEvndispRunParameter_H
 
 #include <TDatime.h>
+#include <TMath.h>
 #include <TNamed.h>
 #include <TROOT.h>
 #include <TSystem.h>
@@ -29,12 +30,12 @@ using namespace std;
 class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
 {
     public:
-    
+
         // local host parameters
         string fEventDisplayUser;
         string fEventDisplayHost;
         string fEventDisplayDate;
-        
+
         // computer system parameters
         string fEventDisplayBuildCompiler;
         string fEventDisplayBuildCompilerVersion;
@@ -42,24 +43,24 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
         string fEventDisplayBuildNode;
         string fEventDisplayBuildDir;
         SysInfo_t* fEventDisplaySystemInfo;
-        
+
         // root parameters
         string fEventDisplayBuildROOTVersion;
         int    fEventDisplayBuildROOTVersionInt;
-        
+
         // JOB ids
         int    fSGE_TASK_ID;
-        
+
         // DB parameters
         bool   fuseDB;
         string fDBRunType;                        // run type according to DB
         string fDBRunStartTimeSQL;                // run start (SQL type)
-        string fDBRunStoppTimeSQL;                // run stopp (SQL type)
+        string fDBRunStoppTimeSQL;                // run stop (SQL type)
         double fDBDataStartTimeMJD;               // run start (mjd)
-        double fDBDataStoppTimeMJD;               // run stopp (mjd)
+        double fDBDataStoppTimeMJD;               // run stop (mjd)
         double fDBDataStartTimeSecOfDay;          // run start (sec of day)
-        double fDBDataStoppTimeSecOfDay;          // run stopp (sec of day)
-        
+        double fDBDataStoppTimeSecOfDay;          // run stop (sec of day)
+
         // run parameters
         int    frunnumber;                        // runnumber
         string fRunTitle;                         // run title (usually empty, useful for debugging)
@@ -73,14 +74,14 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
         int    fFirstEvent;                       // skip up till this event
         int    fTimeCutsMin_min;                  // start to analyse run at this min
         int    fTimeCutsMin_max;                  // stop to analyse this run at this min
-        
+
         bool fprintdeadpixelinfo ;       // DEADCHAN if true, will print list of dead pixels
         // at end of run to evndisp.log
-        
+
         bool fSaveDeadPixelRegistry ; // will save an extra tree containing info about the dead pixels
-        
+
         bool fForceLLImageFit ;          // FORCELL if true, will use log-likelihood image fitting
-        // on all images, irregardless of if they are near the
+        // on all images, regardless of if they are near the
         // edge of the camera or not.  Set in
         // EVNDISP.reconstruction.runparameter
         bool fSquaredImageCalculation;   // use unusual definition of image calculation (weighted by square)
@@ -89,31 +90,31 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
         double fMinimizeTimeGradient_minGradforFit;
         double fMinimizeTimeGradient_minLoss;
         double fMinimizeTimeGradient_minNtubes;
-        
+
         string fInstrumentEpoch;                  // Instrumental epoch (e.g. for VTS V5 or V6)
         unsigned int fAtmosphereID;               // corsika ID of atmosphere
         string fEpochFile;                        // file with list of epochs and atmospheres
-        
+
         float  fRunDuration;                      // duration of runs in [s]
-        
+
         // output parameters
         bool   ffillhistos;                       // fill some analysis histograms
         string foutputfileName;                   // file name for analysis output (root file), -1 = no output
-        
+
         // debugging
         bool  fDebug;                             // print debug output
         bool  fPrintSmallArray;                   // some printout for small arrays only
         unsigned int fPrintAnalysisProgress;      // print a line each time this number of events have been processed
-        unsigned int fPrintGrisuHeader;           // Print full grisu header, includeing detector config file used in
+        unsigned int fPrintGrisuHeader;           // Print full grisu header, including detector config file used in
         //   grisu simulations (sims only, from VBF header), OR name of
         //   config file for detector simulation if available
-        
+
         // array/telescope geometry parameters
         unsigned int fNTelescopes;                // number of telescopes
         vector<string> fcamera;                   // name of camera configuration files
         vector< unsigned int > fTelToAnalyze;     // analyze only this telescope (Telescope 1 = 0!! )
         bool   fUseVBFSampleLength;               // use number of samples from VBF file (ignore .cfg file)
-        
+
         // pointing parameters
         string fTargetName;                       // target name
         double fTargetDec;                        // target declination [deg] (J2000)
@@ -131,7 +132,7 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
         vector<double> fPointingErrorY;           // pointing error, in camera coordinates [deg]
         double fCheckPointing;                    // stop run if pointing difference between calculated pointing direction and vbf is larger than this value
         bool fDBCameraRotationMeasurements;       // read camera rotations from DB
-        
+
         // calibration (pedestals, gains, etc.)
         bool   fcalibrationrun;                   // true if this is a pedestal/gain/toff calculation run
         string fcalibrationfile;                  // file with file names for calibration
@@ -181,7 +182,7 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
         vector< float > fthroughoutCorrectionGFactor; // throughput correction (e.g., gain loss) --> applied to FADC values
         bool   fL2TimeCorrect;                    // use L2 pulses to correct FADC times (default: on )
         unsigned fCalibrationDataType;            // for DSTs: kind of calibration data available: 1: full (peds, pedvars, etc). 0: (no calibration data)
-        
+
         //////////////////////////////////////////////////
         // FADC integration
         string  fFADCChargeUnit;                  // FADC charge unit (DC or PE)
@@ -203,9 +204,9 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
         vector< int >  fsumfirst_maxT0startDiff;              // maximum difference between T0 and trace integration window start
         vector< double > fSumWindowMaxTimeDifferenceLGtoHG;   // maximum difference between lg and hg window in doublepass method
         vector< double > fSumWindowMaxTimedifferenceToDoublePassPosition; // maximum difference between doublepass calculated window start and t0 (in samples, default: 10 )
-        
+
         float  fFADCtoPhe[VDST_MAXTELTYPES];                  //! default conversion factor c[phes/fadc]: [phes]=c*[fadc] for certain integ. window (4slices)
-        
+
         // FADC timing parameters
         vector< float > fpulsetiminglevels;       // levels at which timing of FADC pulses is calculated
         unsigned int fpulsetiming_tzero_index;
@@ -213,11 +214,11 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
         unsigned int fpulsetiming_max_index;
         unsigned int fpulsetiming_triggertime_index;
         vector< bool > fSumWindow_searchmaxreverse;
-        
+
         // image cleaning
         vector< VImageCleaningRunParameter* >  fImageCleaningParameters;
         vector< VImageCleaningRunParameter* >  fImageCleaningParameters_DB_Pass1;      // image cleaning parameters for double pass, pass1
-        
+
         // image analysis
         int    fImageLL;                          // loglikelihood image parameterisation 0=off/1=on/2=verbose mode (default: 0=off )
         // neighbour scaling
@@ -237,7 +238,7 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
         bool   ifReadIPRfromDatabase;             // flag to read IPR from external IPR database
         bool   ifCreateIPRdatabase;               // flag to create external IPR database
         bool   ifReadIPRfromDSTFile;              // flat to read IPR graph from DST file
-        
+
         string freconstructionparameterfile;      // reconstruction parameter file
         // MC parameters
         string fsimu_pedestalfile;                // use external pedestal file for MC
@@ -249,7 +250,7 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
         bool   fIgnoreCFGversions;                // ignore configuration file versions
         double finjectGaussianNoise;              // add Gaussian noise to trace (standard deviation in units of DC)
         UInt_t finjectGaussianNoiseSeed;          // seed for random Gaussian noise to trace adding
-        
+
         int fgrisuseed;
         int ftelescopeNOffset;                    // offset in telescope numbering (default: first tele = 0 ), for GrIsu Reader
         int fsampleoffset;                        // offset in samples
@@ -260,13 +261,13 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
         int fMCNdeadSeed;                         // seed for setting pixels randomly dead
         int fMCNdeadboard;                        // number of boards set randomly dead (10 dead pixels in a row)
         double fMCScale;                          // scale factor for MC data
-        
+
         // tree filling
         unsigned int fShortTree;                  // 0: full tree; 1: short tree
         unsigned int fwriteMCtree;                // 0: do not write MC tree
         bool fWriteTriggerOnly;                   // true: write triggered events for simulation only
         bool fFillMCHistos;                       // true: fill MC histograms with thrown events
-        
+
         // display parameters
         bool   fdisplaymode;                      // display mode or command line mode
         bool   floopmode;                         // infinite event loop
@@ -275,40 +276,40 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
         bool fPlotRaw;                            // plot raw values only, used fpeds = 0
         bool fPlotPaper;                          // clean up plots for papers and talks (no dead channels, no small text, ...)
         unsigned int fPlotAllInOneMethod;         // from which method are the angular reconstruction results to taken to plot in all in one window
-        
+
         // star catalogue
         string fStarCatalogueName;
         float  fMinStarBrightness_B;
         float  fMinStarPixelDistance_deg;        // closest distance of a pixel to a bright star
         int    fMinStarNTubes;                   // closest distance analysis applies only for image smaller than this number
-        
+
         // muon parameters
         bool fmuonmode;                           // search for complete muon rings, Martin
         // Hough transform muon parameters
         bool fhoughmuonmode;                      // Use hough transform muon analysis
-        
+
         // write pulse histograms to gain files
         int  fwriteLaserPulseN;                    // number of pulse histogram written to gain file
         bool fwriteAverageLaserPulse;              // write average laser pulse to file
-        
+
         // dst parameters
         string fdstfile;                          // dst output file name (root file)
         int fdstminntubes;                        // write only events with more than fdstminntubes ntubes into dst file
         bool fdstwriteallpixel;                   // write all information of all pixel into dst output files
         bool fdstcalibration;                     // write only the branches required for calibration to DST file
-        
+
         TString  fNNGraphsFile;
         TString  fIPRdatabase;                    // file to read IPRs from external database
         TString  fIPRdatabaseFile;                // file to write the IPR database
-        
+
         // functions
         void print();
         void print( int iEV );
         void printCTA_DST();
-        
+
         VEvndispRunParameter( bool bSetGlobalParameter = true );
         ~VEvndispRunParameter();
-        
+
         unsigned int getAtmosphereID( bool iUpdateInstrumentEpoch = false );
         string       getInstrumentEpoch( bool iMajor = false,
                                          bool iUpdateInstrumentEpoch = false );
@@ -326,7 +327,7 @@ class VEvndispRunParameter : public TNamed, public VGlobalRunParameter
         {
             return fuseDB;
         }
-        
+
         ClassDef( VEvndispRunParameter, 1002 ); //(increase this number)
 };
 #endif

--- a/inc/VGlobalRunParameter.h
+++ b/inc/VGlobalRunParameter.h
@@ -4,6 +4,7 @@
 #define VGlobalRunParameter_H
 
 #include <TChain.h>
+#include <TMath.h>
 #include <TSystem.h>
 #include <TTree.h>
 #include <TROOT.h>
@@ -37,16 +38,16 @@ using namespace std;
 class VGlobalRunParameter
 {
     private:
-    
+
         static bool      bReadRunParameter;
         static bool      bDebug;                                         // print debug output
-        
+
         static string       fObservatory;
         static double       fObservatory_Latitude_deg;
         static double       fObservatory_Longitude_deg;
         static double       fObservatory_Height_m;
-        
-        
+
+
         // OUTPUT TREE VERSION
         //
         // changes from 5 to 6: LTrig  now ULong64_t
@@ -55,23 +56,23 @@ class VGlobalRunParameter
         //
         // changes from 7 to 8: add MC primary to showerpars
         static unsigned int fEVNDISP_TREE_VERSION;
-        
+
         static string    fDBServer;                                         // database location (VTS)
         static string    fRawDataServer;                                    // location of raw data (VTS)
-        
+
         // DIRECTORIES
         static string fEVNDISPAnaDataDirectory;          // directory where all data (detectorgeometry, ...) is expected and written to (output file)
         static string fVBFRawDataDirectory;              // directory with VERITAS vbf data (vbf files)
         static string fEVNDISPCalibrationDataDirectory;  // directory where calibration data is expected and written to
         static string fEVNDISPOutputDirectory;           // output- and result files are written into this directory
-        
+
     public:
-    
+
         static string       fEVNDISP_VERSION;                             // EVNDISPLAY VERSION
-        
+
         VGlobalRunParameter( bool bSetGlobalParameter = true );
         virtual ~VGlobalRunParameter();
-        
+
         string       getDBServer() const
         {
             return fDBServer;
@@ -151,7 +152,7 @@ class VGlobalRunParameter
         }
         bool         setDirectory_EVNDISPCalibrationData( string iDir );
         bool         update( TChain* ic );
-        
+
         ClassDef( VGlobalRunParameter, 10 );
 };
 

--- a/inc/VPedestalLowGain.h
+++ b/inc/VPedestalLowGain.h
@@ -12,6 +12,7 @@
 #include "TH1F.h"
 #include "TFile.h"
 #include "TList.h"
+#include "TMath.h"
 #include "TROOT.h"
 
 using namespace std;
@@ -19,37 +20,37 @@ using namespace std;
 class VPedestalLowGain
 {
     private:
-    
+
         bool   fDebug;
-        
+
         unsigned int fChannel1_min;
         unsigned int fChannel1_max;
         TFile*       fFile1;
-        
+
         unsigned int fChannel2_min;
         unsigned int fChannel2_max;
         TFile*       fFile2;
-        
+
         unsigned int fTelescopeID;
         unsigned int fSumWindow_min;
         unsigned int fSumWindow_max;
-        
+
         vector< TH1F* > fHped;
         vector< string > fPedLine;
-        
+
         vector< double > fPed1;
         vector< double > fPed2;
-        
-        
+
+
         TFile*           readLowGainHistograms( string iFile, unsigned int iChannel_min, unsigned int iChannel_max );
         vector< double > readPedestalFiles( string iFile );
         void             reset();
-        
+
     public:
-    
+
         VPedestalLowGain();
         ~VPedestalLowGain() {}
-        
+
         // combine two low gain pedestal files
         bool readLowGainPedestalFiles( string iFile1, string iFile2 );
         void setChannelNumberRange( unsigned int iChannel1_min = 0, unsigned int iChannel1_max = 249, unsigned int iChannel2_min = 250, unsigned int iChannel2_max = 499 );
@@ -64,11 +65,11 @@ class VPedestalLowGain
         }
         bool combineLowGainPedestalFileForAllTelescopes( unsigned int iNTel, string iCalibrationDirectory, string iRun1, string iRun2, string iOutRun );
         bool writeLowGainPedestalFile( string iOutFileName );
-        
+
         // compare two low gain pedestal files
         void printDifferences( double iTolerance = 0.5 );
         bool readPedestalFiles( string iFile1, string iFile2 );
-        
+
 };
 
 #endif

--- a/inc/VPlotAnasumHistograms.h
+++ b/inc/VPlotAnasumHistograms.h
@@ -46,23 +46,23 @@ struct sSource
 class VPlotAnasumHistograms : public VAnalysisUtilities, public VPlotUtilities, public VHistogramUtilities
 {
     private:
-    
+
         string fAnasumDataFile;    //! name of input anasum file
         int    fRunNumber;         //! -1 all runs (run number for plotting can be set later)
         bool   fDebug;
         string fPlotMode;
-        
+
         bool   fPlotCorrelated;    //! plot correlated sky plots
         float  fPlotDrawPSF;       //! plot PSF on top of sky maps (radius in deg)
         bool   fPlotUseHours;      //! plot hour/min/sec on sky maps axis
         int    fPlotZeroHours;     //! quick fix for hour axis (definition might depend on time zone)
-        
+
         // some run Summary info needed for skymaps
         double fSkyMapCentreDecJ2000;
         double fSkyMapCentreRAJ2000;
         double fTargetShiftWest;
         double fTargetShiftNorth;
-        
+
         // histograms
         TH1D* hmscw_on;
         TH1D* hmscw_off;
@@ -70,32 +70,32 @@ class VPlotAnasumHistograms : public VAnalysisUtilities, public VPlotUtilities, 
         TH1D* hmscl_on;
         TH1D* hmscl_off;
         TH1D* hmscl_diff;
-        
+
         TH1D* htheta2_on;
         TH1D* htheta2_off;
         TH1D* htheta2_diff;
-        
+
         // helper functions
         TH1D* doQfactors( TH1D* hon, TH1D* hoff, TH1D* hdiff, bool bUpper, int iMethod, double iSourceStrength );
         TH2D* reflectXaxis( TH2D* h = 0, char* iNewName = 0 );
-        
+
         /////////////////////////////////////////////////////////////////////
         /////////////////////////////////////////////////////////////////////
     public:
-    
+
         VPlotAnasumHistograms();
         VPlotAnasumHistograms( string ifile, int ion = -1 );
         ~VPlotAnasumHistograms() {};
-        
+
         void convert_derotated_RADECJ2000( double x = 0, double y = 0, double xerr = 0, double yerr = 0 );
-        
-        void drawPSF( TCanvas* c = 0, string iFile = 0, TH2D* h2 = 0, float iPSF = 0.1 );
+
+        void drawPSF( TCanvas* c = 0, string iFile = "", TH2D* h2 = 0, float iPSF = 0.1 );
         //   void fit_energy(double minE = -0.5, double maxE = 0.5 );
         bool openDataFile( string ifile );
-        
+
         void help();                                                       // this will print all available functions
-        
-        
+
+
         // plotting functions
         void            plot_deadTimes();
         void            plot_mscPlots( int irebin = 2, double xmin = -2., double xmax = 4., string mscwfile = "" );
@@ -126,7 +126,7 @@ class VPlotAnasumHistograms : public VAnalysisUtilities, public VPlotUtilities, 
         void            plot_excludedRegions( TCanvas* c, int iLineColor = 6 );
         TH1D*           plot_triggerpattern( int ntel = 3, bool bPlot = true );
         TCanvas*	plot_cumulativeSignificance( bool doSqrtFit = true );
-        
+
         void            setPlottingCorrelatedHistograms( bool iB = false )
         {
             fPlotCorrelated = iB;
@@ -145,7 +145,7 @@ class VPlotAnasumHistograms : public VAnalysisUtilities, public VPlotUtilities, 
             fDebug = iB;    // more debug output to screen
         }
         bool            setRunNumber( int iRun );                                      // select run for plotting
-        
+
         ClassDef( VPlotAnasumHistograms, 16 );
 };
 

--- a/inc/VPointingCorrectionsTreeReader.h
+++ b/inc/VPointingCorrectionsTreeReader.h
@@ -6,6 +6,7 @@
 #include "TChain.h"
 #include "TTree.h"
 
+#include <cmath>
 #include <iostream>
 
 using namespace std;
@@ -16,9 +17,9 @@ class VPointingCorrectionsTreeReader
         float fPointingErrorX;
         float fPointingErrorY;
         bool  fPointingCorrectionTreeSetting;
-        
+
         TChain* fTree;
-        
+
     public:
         VPointingCorrectionsTreeReader( TChain* t = 0 );
         bool is_initialized()
@@ -27,11 +28,11 @@ class VPointingCorrectionsTreeReader
         }
         int getEntry( Long64_t );
         Long64_t getEntries();
-        
+
         float getCorrected_cen_x( float cen_x );
         float getCorrected_cen_y( float cen_y );
         float getCorrected_phi( float cen_x, float cen_y, float d, float s, float sdevxy );
-        
+
 };
 
 #endif

--- a/src/VInstrumentResponseFunctionRunParameter.cpp
+++ b/src/VInstrumentResponseFunctionRunParameter.cpp
@@ -9,24 +9,24 @@ VInstrumentResponseFunctionRunParameter::VInstrumentResponseFunctionRunParameter
 {
     fFillingMode = 0;
     fEffArea_short_writing = false;
-    
+
     fInstrumentEpoch = "NOT_SET";
-    
+
     fNSpectralIndex = 1;
     fSpectralIndexMin = 2.0;
     fSpectralIndexStep = 0.1;
-    
+
     fReconstructionType = NOT_SET;
     fEnergyReconstructionMethod = 0;
     fEnergyAxisBins_log10 = 60;
     fEnergyAxis_logTeV_min = -2.;
     fEnergyAxis_logTeV_max =  4.;
     fIgnoreEnergyReconstructionQuality = false;
-    
+
     fMCEnergy_min = -99.;
     fMCEnergy_max = -99.;
     fMCEnergy_index = 5.;
-    
+
     // IRF histogram bin definition
     fBiasBin = 300;                       // Energy bias (bias bins)
     fLogAngularBin = 100;                 // Angular resolution Log10 (bins)
@@ -36,49 +36,49 @@ VInstrumentResponseFunctionRunParameter::VInstrumentResponseFunctionRunParameter
     fhistoNEbins = fEnergyAxisBins_log10; // E binning (affects 2D histograms only)
     fhistoNEbins_logTeV_min = fEnergyAxis_logTeV_min;
     fhistoNEbins_logTeV_max = fEnergyAxis_logTeV_max;
-    
+
     fGammaHadronCutSelector = -1;
     fDirectionCutSelector = -1;
-    
+
     fAzimuthBins = true;
     fIsotropicArrivalDirections = false;
-    
+
     fIgnoreFractionOfEvents = 0.;
-    
+
     fTelescopeTypeCuts = false;
-    
+
     fFillMCHistograms = false;
-    
+
     fgetXoff_Yoff_afterCut = false;
-    
+
     fCoreScatterMode = "";
     fCoreScatterRadius = 0.;
-    
+
     fViewcone_min = -1.;
     fViewcone_max = -1.;
-    
+
     fdatafile = "";
     fMCdatafile_tree = "";
     fMCdatafile_histo = "";
     fGammaHadronProbabilityFile = "";
-    
+
     fze = 0.;
     fnoise = 0;
     fpedvar = 0.;
     fXoff  = 0.;
     fYoff  = 0.;
-    
+
     fWobbleIsotropic = 0.;
-    
+
     telconfig_ntel = 0;
     telconfig_arraycentre_X = 0.;
     telconfig_arraycentre_Y = 0.;
     telconfig_arraymax = 0.;
-    
+
     fCREnergySpectrumFile = "";
     fCREnergySpectrumID = 0;
     fCREnergySpectrum = 0;
-    
+
     fWriteEventdatatrees = "FALSE";
 }
 
@@ -104,12 +104,12 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameterFromTextFile( stri
     cout << endl;
     cout << "========================================" << endl;
     cout << "run parameter file (" << ifile << ")" << endl;
-    
+
     while( getline( is, is_line ) )
     {
         if( is_line.size() > 0 )
         {
-        
+
             istringstream is_stream( is_line );
             is_stream >> temp;
             if( temp != "*" )
@@ -257,7 +257,7 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameterFromTextFile( stri
                 {
                     string temp2;
                     is_stream >> temp2;
-                    
+
                     if( temp2 == "GEO" || temp2 == "TL" )
                     {
                         fReconstructionType = GEO;
@@ -276,6 +276,10 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameterFromTextFile( stri
                     {
                         fReconstructionType = DEEPLEARNER;
                     }
+                    else if( temp2 == "XGBSTEREO" )
+                    {
+                        fReconstructionType = XGBSTEREO;
+                    }
                     else
                     {
                         fReconstructionType = NOT_SET;
@@ -289,7 +293,7 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameterFromTextFile( stri
                     cout << "VInstrumentResponseFunctionRunParameter::readRunParameter Warning: Unknown analysis type,";
                     cout << " will use GammaHadron cut file to decide." << endl;
                 }
-                
+
             }
             // energy reconstruction quality
             else if( temp == "ENERGYRECONSTRUCTIONQUALITY" )
@@ -452,7 +456,7 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameterFromTextFile( stri
         }
     }
     cout << "========================================" << endl << endl;
-    
+
     //////////////////////////////////////////////////////////////////////////////////////
     // fill some parameters
     // read run parameters from this file
@@ -467,7 +471,7 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameterFromTextFile( stri
     {
         return false;
     }
-    
+
     /////////////////////////////////////////////////////////////////
     // define azimuth bins
     fAzMin.clear();
@@ -484,7 +488,7 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameterFromTextFile( stri
             fAzMin.push_back( fAzMin.back() + 45. );
             fAzMax.push_back( fAzMax.back() + 45. );
         }
-        
+
         /*
          * 45 deg intervals
         fAzMin.push_back( 135.0 );
@@ -504,7 +508,7 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameterFromTextFile( stri
     fAzMax.push_back( +1.e3 );
     // WARNING: if this last rule changes (if the last bin is NOT filled ANY MORE with all simulated event regardless of their az)
     //          then the az_bin_index must be changed in VEffectiveAreaCalculator::fill
-    
+
     /////////////////////////////////////////////////////////////////
     // define  spectral index bins
     fSpectralIndex.clear();
@@ -512,7 +516,7 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameterFromTextFile( stri
     {
         fSpectralIndex.push_back( fSpectralIndexMin + ( double )i * fSpectralIndexStep );
     }
-    
+
     return true;
 }
 
@@ -536,7 +540,7 @@ TTree* VInstrumentResponseFunctionRunParameter::getTelConfigTree()
     {
         return t->CloneTree( -1 );
     }
-    
+
     return 0;
 }
 
@@ -550,7 +554,7 @@ VMonteCarloRunHeader* VInstrumentResponseFunctionRunParameter::readMCRunHeader()
     {
         iF = c.GetFile();
     }
-    
+
     if( !iF )
     {
         cout << "VInstrumentResponseFunctionRunParameter::readMCRunHeader: error opening data file: " << fdatafile << endl;
@@ -565,7 +569,7 @@ VMonteCarloRunHeader* VInstrumentResponseFunctionRunParameter::readMCRunHeader()
         cout << "exiting..." << endl;
         exit( EXIT_FAILURE );
     }
-    
+
     fCoreScatterRadius = iMC->core_range[0];
     // check if core scattering area is circular
     if( fCoreScatterRadius < 1.e-5 && iMC->core_pos_mode == 1 )
@@ -590,7 +594,7 @@ VMonteCarloRunHeader* VInstrumentResponseFunctionRunParameter::readMCRunHeader()
     fMCEnergy_min = iMC->E_range[0];
     fMCEnergy_max = iMC->E_range[1];
     fMCEnergy_index = iMC->spectral_index;
-    
+
     return iMC;
 }
 
@@ -605,7 +609,7 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameters( string ifilenam
         cout << "Information: using first file in list of files to determinate run parameters" << endl;
         cout << "(all files should have same energy range and spectral index)" << endl;
     }
-    
+
     TChain c( "data" );
     TFile* iFile = 0;
     if( c.Add( ifilename.c_str() ) )
@@ -652,7 +656,7 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameters( string ifilenam
     {
         return false;
     }
-    
+
     double x = 0.;
     double y = 0.;
     i_data->SetBranchAddress( "MCxoff", &x );
@@ -676,7 +680,7 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameters( string ifilenam
             fYoff = 0.;
         }
     }
-    
+
     ////////////////////////////////////////////////
     // read array parameters
     ////////////////////////////////////////
@@ -692,9 +696,9 @@ bool VInstrumentResponseFunctionRunParameter::readRunParameters( string ifilenam
     telconfig_arraycentre_X = telconfig->getArrayCentreX();
     telconfig_arraycentre_Y = telconfig->getArrayCentreY();
     telconfig_arraymax      = telconfig->getArrayMaxSize();
-    
+
     ////////////////////////////////////////
-    
+
     return true;
 }
 
@@ -707,7 +711,7 @@ bool VInstrumentResponseFunctionRunParameter::testRunparameters()
         cout << "   no MC file given" << endl;
         return false;
     }
-    
+
     return true;
 }
 
@@ -769,7 +773,7 @@ void VInstrumentResponseFunctionRunParameter::print()
     {
         cout << "Instrument epoch not set" << endl;
     }
-    
+
     cout << endl;
     cout << "cuts: " << endl;
     for( unsigned int i = 0; i < fCutFileName.size(); i++ )
@@ -803,7 +807,7 @@ void VInstrumentResponseFunctionRunParameter::print()
     cout << "reconstruction type " << fReconstructionType << endl;
     cout << "energy reconstruction method " << fEnergyReconstructionMethod << endl;
     cout << endl;
-    
+
     cout << "input Monte Carlo with following parameters (will be modified later): " << endl;
     cout << "\t core range: " << fCoreScatterRadius;
     if( fCoreScatterMode.size() > 0 )
@@ -818,14 +822,14 @@ void VInstrumentResponseFunctionRunParameter::print()
     cout << "\t ze=" << fze << " [deg], noise=" << fnoise << " (pedvar: " << fpedvar;
     cout << "), wobble offset w=" << sqrt( fXoff * fXoff + fYoff * fYoff ) << " [deg]";
     cout << endl;
-    
+
     cout << "azimuth bins (" << fAzMin.size() << "): ";
     for( unsigned int i = 0; i < fAzMin.size(); i++ )
     {
         cout << " " << i << " [" << fAzMin[i] << "," << fAzMax[i] << "]";
     }
     cout << endl;
-    
+
     cout << endl;
     cout << "array configuration: ";
     cout << telconfig_ntel;
@@ -861,7 +865,7 @@ bool VInstrumentResponseFunctionRunParameter::readCRSpectralParameters()
     {
         return true;
     }
-    
+
     VEnergySpectrumfromLiterature espec( fCREnergySpectrumFile );
     if( espec.isZombie() )
     {
@@ -891,7 +895,7 @@ bool VInstrumentResponseFunctionRunParameter::readCRSpectralParameters()
     {
         fCREnergySpectrum = 0;
     }
-    
+
     return true;
 }
 

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -215,7 +215,7 @@ int main( int argc, char* argv[] )
 
     // TODO set xgb stereo reconstruction
     string fXGB_stereo_file_suffix = "xgb_stereo";
-    CData d( c, true, true, fXGB_stereo_file_suffix );
+    CData d( c, true, true, fRunPara->fdatafile.c_str(), fXGB_stereo_file_suffix );
     for( unsigned int i = 0; i < fCuts.size(); i++ )
     {
         fCuts[i]->setDataTree( &d );

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -36,12 +36,8 @@ using namespace std;
 VEffectiveAreaCalculatorMCHistograms* copyMCHistograms( TChain* c );
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////////
 int main( int argc, char* argv[] )
 {
-
     // print version only
     if( argc == 2 )
     {
@@ -85,7 +81,7 @@ int main( int argc, char* argv[] )
     // read run parameters from file
     VInstrumentResponseFunctionRunParameter* fRunPara = new VInstrumentResponseFunctionRunParameter();
     fRunPara->SetName( "makeEffectiveArea_runparameter" );
-    if( !fRunPara->readRunParameterFromTextFile( argv[1] ) )
+    if(!fRunPara->readRunParameterFromTextFile( argv[1] ) )
     {
         cout << "error reading runparameters from text file" << endl;
         cout << "exiting..." << endl;
@@ -94,7 +90,7 @@ int main( int argc, char* argv[] )
     fRunPara->print();
 
     /////////////////////////////////////////////////////////////////
-    // open output file and write results to dist
+    // open output file and write results to disk
     TFile* fOutputfile = new TFile( fOutputfileName.c_str(), "RECREATE" );
     if( fOutputfile->IsZombie() )
     {
@@ -217,7 +213,9 @@ int main( int argc, char* argv[] )
         exit( EXIT_FAILURE );
     }
 
-    CData d( c, true, true );
+    // TODO set xgb stereo reconstruction
+    string fXGB_stereo_file_suffix = "xgb_stereo";
+    CData d( c, true, true, fXGB_stereo_file_suffix );
     for( unsigned int i = 0; i < fCuts.size(); i++ )
     {
         fCuts[i]->setDataTree( &d );
@@ -506,10 +504,10 @@ VEffectiveAreaCalculatorMCHistograms* copyMCHistograms( TChain* c )
         TChainElement* chEl = 0;
         TIter next( fileElements );
         unsigned int z = 0;
-        while( ( chEl = ( TChainElement* )next() ) )
+        while(( chEl = ( TChainElement* )next() ) )
         {
             TFile* ifInput = new TFile( chEl->GetTitle() );
-            if( !ifInput->IsZombie() )
+            if(!ifInput->IsZombie() )
             {
                 if( z == 0 )
                 {
@@ -519,7 +517,7 @@ VEffectiveAreaCalculatorMCHistograms* copyMCHistograms( TChain* c )
                 {
                     if( iMC_his )
                     {
-                        iMC_his->add( ( VEffectiveAreaCalculatorMCHistograms* )ifInput->Get( "MChistos" ) );
+                        iMC_his->add(( VEffectiveAreaCalculatorMCHistograms* )ifInput->Get( "MChistos" ) );
                     }
                     ifInput->Close();
                 }

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -12,6 +12,7 @@
 #include "TMath.h"
 #include "TObjArray.h"
 #include "TStopwatch.h"
+#include "TSystem.h"
 #include "TTree.h"
 
 #include "VGlobalRunParameter.h"
@@ -34,6 +35,51 @@
 using namespace std;
 
 VEffectiveAreaCalculatorMCHistograms* copyMCHistograms( TChain* c );
+
+/*
+ * load and return data chain
+ *
+ * Add XGB stereo tree as friend if required.
+ * Resolves wildcards.
+*/
+TChain *load_data_chain( string tree_file_name, unsigned int reconstruction_type )
+{
+    TChain *c = new TChain( "data" );
+    TChain *xgb = new TChain( "StereoAnalysis" );
+
+    // resolve wildcard
+    vector<std::string> files;
+    string cmd = "ls " + tree_file_name;
+    string out = gSystem->GetFromPipe( cmd.c_str() ).Data();
+    istringstream iss(out);
+    for (string f; iss >> f; )
+        files.push_back(f);
+
+    // add files to string - add XGB tree as friend if needed.
+    for( unsigned int i = 0; i < files.size(); i++ )
+    {
+        if( !c->Add(files[i].c_str(), -1 ))
+        {
+            cout << "Error while trying to add mscw data tree from file " << files[i] << endl;
+            cout << "exiting..." << endl;
+            exit( EXIT_FAILURE );
+        }
+
+        if( reconstruction_type == XGBSTEREO )
+        {
+            xgb->Add( (files[i].substr( 0, files[i].find_last_of( "." ) ) + ".xgb_stereo.root").c_str() );
+        }
+    }
+    if( reconstruction_type == XGBSTEREO )
+    {
+        c->AddFriend( xgb );
+    }
+    else
+    {
+        delete xgb;
+    }
+    return c;
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 int main( int argc, char* argv[] )
@@ -205,20 +251,8 @@ int main( int argc, char* argv[] )
 
     /////////////////////////////////////////////////////////////////////////////
     // load data chain
-    TChain* c = new TChain( "data" );
-    if( !c->Add( fRunPara->fdatafile.c_str(), -1 ) )
-    {
-        cout << "Error while trying to add mscw data tree from file " << fRunPara->fdatafile  << endl;
-        cout << "exiting..." << endl;
-        exit( EXIT_FAILURE );
-    }
-
-    string fXGB_stereo_file_suffix = "";
-    if( fRunPara->fReconstructionType == XGBSTEREO )
-    {
-       fXGB_stereo_file_suffix = "xgb_stereo";
-    }
-    CData d( c, true, true, fRunPara->fdatafile.c_str(), fXGB_stereo_file_suffix );
+    TChain *c = load_data_chain( fRunPara->fdatafile.c_str(), fRunPara->fReconstructionType );
+    CData d( c, true, true );
     for( unsigned int i = 0; i < fCuts.size(); i++ )
     {
         fCuts[i]->setDataTree( &d );

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -213,8 +213,11 @@ int main( int argc, char* argv[] )
         exit( EXIT_FAILURE );
     }
 
-    // TODO set xgb stereo reconstruction
-    string fXGB_stereo_file_suffix = "xgb_stereo";
+    string fXGB_stereo_file_suffix = "";
+    if( fRunPara->fReconstructionType == XGBSTEREO )
+    {
+       fXGB_stereo_file_suffix = "xgb_stereo";
+    }
     CData d( c, true, true, fRunPara->fdatafile.c_str(), fXGB_stereo_file_suffix );
     for( unsigned int i = 0; i < fCuts.size(); i++ )
     {

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -177,12 +177,12 @@ int main( int argc, char* argv[] )
             f_IRF_Type.push_back( "core_resolution" );
             f_IRF_ContainmentProbability.push_back( 0.68 );
             f_IRF_DuplicationID.push_back( 9999 );           // means no duplication
-            // energy resolution
-            f_IRF_Name.push_back( "energy_resolution" );
-            f_IRF_Type.push_back( "energy_resolution" );
-            f_IRF_ContainmentProbability.push_back( 0.68 );
-            f_IRF_DuplicationID.push_back( 9999 );           // means no duplication
         }
+        // energy resolution
+        f_IRF_Name.push_back( "energy_resolution" );
+        f_IRF_Type.push_back( "energy_resolution" );
+        f_IRF_ContainmentProbability.push_back( 0.68 );
+        f_IRF_DuplicationID.push_back( 9999 );           // means no duplication
     }
     // initialize IRF classes
     for( unsigned int i = 0; i < f_IRF_Name.size(); i++ )

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -42,7 +42,7 @@ VEffectiveAreaCalculatorMCHistograms* copyMCHistograms( TChain* c );
  * Add XGB stereo tree as friend if required.
  * Resolves wildcards.
 */
-TChain *load_data_chain( string tree_file_name, unsigned int reconstruction_type )
+TChain *load_data_chain( string tree_file_name, int reconstruction_type )
 {
     TChain *c = new TChain( "data" );
     TChain *xgb = new TChain( "StereoAnalysis" );

--- a/src/makeEffectiveArea.cpp
+++ b/src/makeEffectiveArea.cpp
@@ -55,6 +55,13 @@ TChain *load_data_chain( string tree_file_name, unsigned int reconstruction_type
     for (string f; iss >> f; )
         files.push_back(f);
 
+    if( files.size() == 0 )
+    {
+        cout << "Error: empty file list read from " << tree_file_name << endl;
+        cout << "exiting..." << endl;
+        exit( EXIT_FAILURE );
+    }
+
     // add files to string - add XGB tree as friend if needed.
     for( unsigned int i = 0; i < files.size(); i++ )
     {
@@ -67,7 +74,12 @@ TChain *load_data_chain( string tree_file_name, unsigned int reconstruction_type
 
         if( reconstruction_type == XGBSTEREO )
         {
-            xgb->Add( (files[i].substr( 0, files[i].find_last_of( "." ) ) + ".xgb_stereo.root").c_str() );
+            if( !xgb->Add( (files[i].substr( 0, files[i].find_last_of( "." ) ) + ".xgb_stereo.root").c_str() ) )
+            {
+                cout << "Error while trying to add XGB data tree from file " << files[i] << endl;
+                cout << "exiting..." << endl;
+                exit( EXIT_FAILURE );
+            }
         }
     }
     if( reconstruction_type == XGBSTEREO )


### PR DESCRIPTION
Add functionality to use XGB stereo results and read them as friends from trees:

- new reconstruction type `* RECONSTRUCTIONTYPE 8` to select XGB stereo trees for direction and energy
- require files with the same name as `mscw.root` files, but with suffix `.mscw.xgb_stereo.root` in the same directory

Additional changes:

- adaption to root 6.38