### PR TITLE
Case insensitive file name checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This changelog is generated using [Towncrier](https://towncrier.readthedocs.io/)
 
 <!-- towncrier release notes start -->
 
+## [v5.18.1](https://github.com/VERITAS-Observatory/EventDisplay_v4/releases/tag/v5.18.1) - 2026-02-11
+
+### Bug Fixes
+
+- Fix prod6 run script to select hyper-array layout applying case-insensitive file name checks.
+
+### New Feature
+
 ## [v5.18.0](https://github.com/VERITAS-Observatory/EventDisplay_v4/releases/tag/v5.18.0) - 2026-02-10
 
 ### New Feature

--- a/dockerfiles/Dockerfile-cta-prod6-run.sh
+++ b/dockerfiles/Dockerfile-cta-prod6-run.sh
@@ -16,10 +16,12 @@ DATAFILE=${1}
 ZE=${2}
 NSB=${3}
 LAYOUTFILE=${4}
+
+datafile_lc=$(printf '%s' "$DATAFILE" | tr '[:upper:]' '[:lower:]')
 # select automatically the corresponding hyper layout
 if [[ -z ${LAYOUTFILE} ]]; then
-    if [[ $DATAFILE == *"paranal"* ]]; then
-        if [[ $DATAFILE == *"scts"* ]]; then
+    if [[ ${datafile_lc} == *paranal* ]]; then
+        if [[ ${datafile_lc} == *scts* ]]; then
             LAYOUTFILE="CTA.prod6S.SCT.hyperarray.lis"
         else
             LAYOUTFILE="CTA.prod6S.hyperarray.lis"
@@ -32,7 +34,7 @@ fi
 OUTPUTFILE=$(basename "${DATAFILE}" .zst)
 rm -f /tmp/"${OUTPUTFILE}"*
 
-if [[ $DATAFILE == *"paranal"* ]]; then
+if [[ ${datafile_lc} == *paranal* ]]; then
     site="south"
 else
     site="north"


### PR DESCRIPTION
Make sure e.g. that 'CTA.prod6S.hyperarray.lis' is selected for 'Paranal' and 'paranal'.